### PR TITLE
Add reusable DNS profile management

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ The LuCI interface also supports reusable DNS profiles.  Each profile stores
 its own bootstrap, upstream, fallback, and upstream-selection settings.  The
 interface identifies the active profile, loads profiles into the form for
 review, creates or updates profiles from the current settings, validates and
-tests their DNS servers, and supports JSON import and export.  Profile editing
-is kept in a collapsed manager on the **Upstreams** tab.  Editable examples for
-Cloudflare, Quad9, Google, and a mixed parallel setup demonstrate the feature.
+tests their DNS servers against a user-selected domain, and supports JSON import
+and export.  Profile editing is kept in a collapsed manager on the **Upstreams**
+tab.  Editable examples for Cloudflare, Quad9, Google, and a mixed parallel
+setup demonstrate the feature.
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@
 it can work as a `DNS-over-HTTPS`, `DNS-over-TLS` or `DNS-over-QUIC` server.
 
 The LuCI interface also supports reusable DNS profiles.  Each profile stores
-its own bootstrap, upstream, and fallback server lists and can apply all three
-lists at once.  Editable example profiles for Cloudflare, Quad9, Google, and a
-mixed parallel setup are included to demonstrate the feature.
+its own bootstrap, upstream, fallback, and upstream-selection settings.  The
+interface identifies the active profile, loads profiles into the form for
+review, creates or updates profiles from the current settings, validates and
+tests their DNS servers, and supports JSON import and export.  Profile editing
+is kept in a collapsed manager on the **Upstreams** tab.  Editable examples for
+Cloudflare, Quad9, Google, and a mixed parallel setup demonstrate the feature.
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,17 @@ it can work as a `DNS-over-HTTPS`, `DNS-over-TLS` or `DNS-over-QUIC` server.
 
 The LuCI interface also supports reusable DNS profiles.  Each profile stores
 its own bootstrap, upstream, fallback, and upstream-selection settings.  The
-interface identifies the active profile, loads profiles into the form for
-review, creates or updates profiles from the current settings, validates and
-tests their DNS servers against a user-selected domain, and supports JSON import
-and export.  Profile editing is kept in a collapsed manager on the **Upstreams**
-tab.  Editable examples for Cloudflare, Quad9, Google, and a mixed parallel
-setup demonstrate the feature.
+interface identifies the active profile, previews changes before loading or
+updating a profile, creates profiles from the current settings, validates their
+contents, and supports versioned JSON import and export.  Its built-in tester
+can measure A, AAAA, or both record types over 1, 3, 5, or 10 attempts, reports
+minimum, average, and maximum response times, tests Bootstrap, Upstream, and
+Fallback endpoints independently, and verifies actual fallback activation.
+Results are sorted and color-coded, and all saved profiles can be compared with
+identical test settings.  The last test domain is stored only in the browser.
+Profile editing is kept in a collapsed manager on the **Upstreams** tab.
+Editable examples for Cloudflare, Quad9, Google, and a mixed parallel setup
+demonstrate the feature.
 
 ## How to install
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ minimum, average, and maximum response times, tests Bootstrap, Upstream, and
 Fallback endpoints independently, and verifies actual fallback activation.
 Results are sorted and color-coded, and all saved profiles can be compared with
 identical test settings.  The last test domain is stored only in the browser.
+Long-running tests use LuCI's direct CGI execution path and are not limited by
+the default 20-second RPC timeout.
 Profile editing is kept in a collapsed manager on the **Upstreams** tab.
 Editable examples for Cloudflare, Quad9, Google, and a mixed parallel setup
 demonstrate the feature.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 `DNS-over-TLS`, `DNS-over-HTTPS`, `DNSCrypt`, and `DNS-over-QUIC`. Moreover,
 it can work as a `DNS-over-HTTPS`, `DNS-over-TLS` or `DNS-over-QUIC` server.
 
+The LuCI interface also supports reusable DNS profiles.  Each profile stores
+its own bootstrap, upstream, and fallback server lists and can apply all three
+lists at once.  Editable example profiles for Cloudflare, Quad9, Google, and a
+mixed parallel setup are included to demonstrate the feature.
+
 ## How to install
 
 1. Go to [here](https://fantastic-packages.github.io/releases/)

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -113,6 +113,25 @@ function validateUniqueServerValue(listName) {
 	};
 }
 
+function validateTestDomain(value) {
+	const domain = String(value || '').trim();
+	const hostname = domain.endsWith('.') ? domain.slice(0, -1) : domain;
+
+	if (!hostname)
+		return _('Test domain is required.');
+
+	if (hostname.length > 253)
+		return _('Test domain must not exceed 253 characters.');
+
+	if (!/^[A-Za-z0-9.-]+$/.test(hostname))
+		return _('Enter an ASCII domain name, for example example.com. International domains must use Punycode.');
+
+	if (hostname.split('.').some((label) => !label || label.length > 63 || label.startsWith('-') || label.endsWith('-')))
+		return _('Test domain contains an invalid DNS label.');
+
+	return true;
+}
+
 function analyzeProfile(data, profiles, sectionName) {
 	const errors = [];
 	const warnings = [];
@@ -529,21 +548,12 @@ return view.extend({
 			]);
 		};
 
-		const testProfile = (profile) => {
-			if (!profile) {
-				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
-				return Promise.resolve();
-			}
-			const data = profileData(profile);
-			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
-			if (!showProfileProblems(result))
-				return Promise.resolve();
-
-			const args = ['--upstream-mode', data.upstream_mode || currentUpstreamMode()];
+		const runProfileTest = (profile, data, domain) => {
+			const args = ['--domain', domain, '--upstream-mode', data.upstream_mode || currentUpstreamMode()];
 			profileListOptions.forEach((option) => data[option].forEach((value) => args.push('--' + option, value)));
 
 			ui.showModal(_('Testing DNS profile'), [
-				E('p', { 'class': 'spinning' }, _('Resolving openwrt.org through “%s”…').format(profileTitle(profile)))
+				E('p', { 'class': 'spinning' }, _('Resolving %s through “%s”…').format(domain, profileTitle(profile)))
 			]);
 
 			return fs.exec('/usr/libexec/dnsproxy-profile-test', args)
@@ -567,7 +577,7 @@ return view.extend({
 						throw new Error(_('The DNS profile test returned no results.'));
 
 					ui.showModal(_('DNS profile test'), [
-						E('p', {}, _('Each server was tested independently by resolving openwrt.org through a temporary local DNS Proxy instance.')),
+						E('p', {}, _('Each server was tested independently by resolving %s through a temporary local DNS Proxy instance.').format(domain)),
 						E('div', { 'class': 'table cbi-section-table' }, [
 							E('div', { 'class': 'tr table-titles' }, [
 								E('div', { 'class': 'th' }, _('Type')),
@@ -591,6 +601,63 @@ return view.extend({
 						])
 					]);
 				});
+		};
+
+		const testProfile = (profile) => {
+			if (!profile) {
+				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+				return Promise.resolve();
+			}
+			const data = profileData(profile);
+			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
+			if (!showProfileProblems(result))
+				return Promise.resolve();
+
+			const domainInput = E('input', {
+				'class': 'cbi-input-text',
+				'type': 'text',
+				'value': 'openwrt.org',
+				'placeholder': 'example.com',
+				'maxlength': '254',
+				'autocomplete': 'off',
+				'spellcheck': 'false'
+			});
+			const validationMessage = E('p', { 'style': 'color:var(--error-color, #c00);white-space:pre-wrap' });
+			const startTest = () => {
+				const domain = String(domainInput.value || '').trim();
+				const validation = validateTestDomain(domain);
+				if (validation !== true) {
+					validationMessage.textContent = validation;
+					domainInput.focus();
+					return Promise.resolve();
+				}
+				return runProfileTest(profile, data, domain);
+			};
+
+			domainInput.addEventListener('keydown', (event) => {
+				if (event.key === 'Enter') {
+					event.preventDefault();
+					startTest();
+				}
+			});
+
+			ui.showModal(_('Test DNS profile'), [
+				E('p', {}, _('Choose the domain used to measure DNS response time. Each configured server will resolve it independently.')),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title' }, _('Test domain')),
+					E('div', { 'class': 'cbi-value-field' }, domainInput)
+				]),
+				validationMessage,
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
+					E('button', {
+						'class': 'btn cbi-button-positive important',
+						'click': ui.createHandlerFn(this, startTest)
+					}, _('Run test'))
+				])
+			]);
+			window.setTimeout(() => domainInput.focus(), 0);
+			return Promise.resolve();
 		};
 
 		s.tab('servers', _('Upstreams'));

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -4,6 +4,7 @@
 'require uci';
 'require rpc';
 'require poll';
+'require ui';
 'require view';
 'require tools.widgets as widgets';
 
@@ -31,6 +32,46 @@ function getServiceStatus() {
 				isrunning = res[conf]['instances'][instance]['running'];
 			} catch (e) { }
 			return isrunning;
+		});
+}
+
+function profileTitle(profile) {
+	return profile.label || profile['.name'];
+}
+
+function applyProfile(profileName) {
+	const profile = uci.sections(conf, 'profile').find((item) => item['.name'] === profileName);
+
+	if (!profile) {
+		ui.addNotification(null, E('p', _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+		return Promise.resolve();
+	}
+
+	const upstreams = L.toArray(profile.upstream).filter(Boolean);
+	if (!upstreams.length) {
+		ui.addNotification(null, E('p', _('The selected DNS profile has no upstream servers.')), 'error');
+		return Promise.resolve();
+	}
+
+	['bootstrap', 'upstream', 'fallback'].forEach((option) => {
+		const values = L.toArray(profile[option]).filter(Boolean);
+		uci.set(conf, 'servers', option, values.length ? values : null);
+	});
+
+	ui.showModal(_('Applying DNS profile'), [
+		E('p', { 'class': 'spinning' }, _('Saving “%s” and reloading DNS Proxy…').format(profileTitle(profile)))
+	]);
+
+	return uci.save()
+		.then(() => uci.apply())
+		.then(() => {
+			ui.hideModal();
+			ui.addNotification(null, E('p', _('DNS profile “%s” has been applied.').format(profileTitle(profile))), 'info');
+			window.setTimeout(() => window.location.reload(), 800);
+		})
+		.catch((err) => {
+			ui.hideModal();
+			ui.addNotification(null, E('p', _('Failed to apply DNS profile: %s').format(err.message || err)), 'error');
 		});
 }
 
@@ -68,6 +109,32 @@ return view.extend({
 		s.render = function (section_id) {
 			return E('div', { class: 'cbi-section' }, [
 				E('div', { id: 'service_status' }, _('Collecting data ...'))
+			]);
+		};
+
+		s = m.section(form.NamedSection, '_profile_switcher');
+		s.render = function () {
+			const profiles = uci.sections(conf, 'profile');
+			const select = E('select', {
+				'id': 'dnsproxy-profile-select',
+				'class': 'cbi-input-select',
+				'disabled': profiles.length ? null : ''
+			}, profiles.map((profile) => E('option', {
+				'value': profile['.name']
+			}, profileTitle(profile))));
+
+			return E('div', { 'class': 'cbi-section' }, [
+				E('h3', {}, _('DNS profiles')),
+				E('p', {}, _('A profile replaces Bootstrap, Upstream and Fallback lists together, then immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are not included.')),
+				E('div', { 'style': 'display:flex;gap:.75em;align-items:center;flex-wrap:wrap' }, [
+					select,
+					E('button', {
+						'class': 'cbi-button cbi-button-positive important',
+						'disabled': profiles.length ? null : '',
+						'click': ui.createHandlerFn(this, () => applyProfile(select.value))
+					}, _('Apply selected profile'))
+				]),
+				profiles.length ? '' : E('p', {}, _('Create and save a profile in the “DNS profile templates” section below first.'))
 			]);
 		};
 
@@ -116,7 +183,8 @@ return view.extend({
 
 		o = s.taboption('main', form.Flag, 'insecure', _('Disable secure TLS cert validation'));
 
-		o = s.taboption('main', form.Flag, 'http3', _('DoH uses H3 first'));
+		o = s.taboption('main', form.Flag, 'http3', _('Enable HTTP/3 for DoH'));
+		o.description = _('Allows HTTP/3 and uses it when it is faster; HTTPS fallback remains available.');
 
 		o = s.taboption('main', form.Value, 'timeout', _('Timeout for queries to remote upstream (default: 10s)'));
 		o.datatype = 'string';
@@ -127,10 +195,23 @@ return view.extend({
 		o = s.taboption('main', form.Value, 'udp_buf_size', _('Size of the UDP buffer in bytes. Set 0 use the system default'));
 		o.datatype = 'uinteger';
 
-		o = s.taboption('main', form.Flag, 'all_servers', _('Parallel queries all upstream'));
-
-		o = s.taboption('main', form.Flag, 'fastest_addr', _('Respond to A or AAAA requests only with the fastest IP address'));
-		o.depends('all_servers', '1');
+		o = s.taboption('main', form.ListValue, 'upstream_mode', _('Upstream selection mode'));
+		o.value('load_balance', _('Load balance (one upstream per request)'));
+		o.value('parallel', _('Parallel (first DNS response wins)'));
+	o.value('fastest_addr', _('Fastest address (tests returned IP addresses)'));
+	o.default = 'load_balance';
+	o.rmempty = false;
+	o.description = _('For the lowest DNS response time choose Parallel. Fastest address performs additional IP reachability tests and is a different, slower operation.');
+	o.cfgvalue = function (section_id) {
+		return uci.get(conf, section_id, 'upstream_mode') ||
+			(uci.get(conf, section_id, 'fastest_addr') === '1' ? 'fastest_addr' : null) ||
+			(uci.get(conf, section_id, 'all_servers') === '1' ? 'parallel' : 'load_balance');
+	};
+	o.write = function (section_id, value) {
+		uci.set(conf, section_id, 'upstream_mode', value);
+		uci.unset(conf, section_id, 'all_servers');
+		uci.unset(conf, section_id, 'fastest_addr');
+	};
 
 		s.tab('cache', _('Cache'));
 
@@ -203,6 +284,26 @@ return view.extend({
 		so.rmempty = false;
 
 		so = ss.option(form.DynamicList, 'fallback', _('Fallback DNS Server'));
+
+		s = m.section(form.GridSection, 'profile', _('DNS profile templates'),
+			_('Create reusable templates here. Applying a template does not modify the template itself.'));
+		s.anonymous = true;
+		s.addremove = true;
+		s.nodescriptions = true;
+		s.addbtntitle = _('Add DNS profile');
+
+		o = s.option(form.Value, 'label', _('Profile name'));
+		o.rmempty = false;
+
+		o = s.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS'));
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'upstream', _('Upstream DNS'));
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'fallback', _('Fallback DNS'));
+		o.modalonly = true;
 
 		return m.render()
 		.then(L.bind(function(m, nodes) {

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -12,6 +12,7 @@ const conf = 'dnsproxy';
 const instance = 'dnsproxy';
 const profileListOptions = ['bootstrap', 'upstream', 'fallback'];
 const upstreamModes = ['load_balance', 'parallel', 'fastest_addr'];
+const testDomainStorageKey = 'luci.dnsproxy.profileTestDomain';
 
 const callServiceList = rpc.declare({
 	object: 'service',
@@ -130,6 +131,21 @@ function validateTestDomain(value) {
 		return _('Test domain contains an invalid DNS label.');
 
 	return true;
+}
+
+function storedTestDomain() {
+	try {
+		const value = window.localStorage.getItem(testDomainStorageKey);
+		return validateTestDomain(value) === true ? String(value).trim() : 'openwrt.org';
+	} catch (e) {
+		return 'openwrt.org';
+	}
+}
+
+function rememberTestDomain(value) {
+	try {
+		window.localStorage.setItem(testDomainStorageKey, value);
+	} catch (e) { }
 }
 
 function analyzeProfile(data, profiles, sectionName) {
@@ -387,6 +403,53 @@ return view.extend({
 			upstream_mode: upstreamModeOption.getUIElement('global').getValue() || currentUpstreamMode()
 		});
 
+		const modeLabel = (mode) => ({
+			load_balance: _('Load balance'),
+			parallel: _('Parallel'),
+			fastest_addr: _('Fastest address'),
+			'': _('Keep current mode')
+		})[mode || ''] || mode;
+
+		const profileDiff = (before, after) => {
+			const rows = [];
+			const addRow = (setting, oldValues, newValues) => {
+				if (listsEqual(oldValues, newValues))
+					return;
+				const oldSet = new Set(oldValues);
+				const newSet = new Set(newValues);
+				const changes = [
+					...oldValues.filter((value) => !newSet.has(value)).map((value) => '- ' + value),
+					...newValues.filter((value) => !oldSet.has(value)).map((value) => '+ ' + value)
+				];
+				if (!changes.length)
+					changes.push(_('Order changed'));
+				rows.push([setting, changes.join('\n')]);
+			};
+
+			if ((before.upstream_mode || '') !== (after.upstream_mode || ''))
+				rows.push([_('Upstream selection mode'), '%s → %s'.format(modeLabel(before.upstream_mode), modeLabel(after.upstream_mode))]);
+			addRow(_('Bootstrap DNS'), before.bootstrap, after.bootstrap);
+			addRow(_('Upstream DNS'), before.upstream, after.upstream);
+			addRow(_('Fallback DNS'), before.fallback, after.fallback);
+			return rows;
+		};
+
+		const renderProfileDiff = (before, after) => {
+			const rows = profileDiff(before, after);
+			if (!rows.length)
+				return E('p', {}, _('No differences.'));
+			return E('div', { 'class': 'table cbi-section-table' }, [
+				E('div', { 'class': 'tr table-titles' }, [
+					E('div', { 'class': 'th' }, _('Setting')),
+					E('div', { 'class': 'th' }, _('Changes'))
+				]),
+				...rows.map((row) => E('div', { 'class': 'tr' }, [
+					E('div', { 'class': 'td' }, row[0]),
+					E('pre', { 'class': 'td', 'style': 'white-space:pre-wrap;margin:0' }, row[1])
+				]))
+			]);
+		};
+
 		const loadProfileIntoForm = (profile, statusNode) => {
 			if (!profile) {
 				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
@@ -396,13 +459,30 @@ return view.extend({
 			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
 			if (!showProfileProblems(result))
 				return;
+			const current = readFormProfile(_('Current form'));
+			const target = Object.assign({}, data, {
+				upstream_mode: data.upstream_mode || current.upstream_mode
+			});
+			const applyProfile = () => {
+				profileListOptions.forEach((option) => serverOptions[option].getUIElement('servers').setValue(data[option]));
+				if (data.upstream_mode)
+					upstreamModeOption.getUIElement('global').setValue(data.upstream_mode);
+				ui.hideModal();
+				statusNode.textContent = _('Loaded profile “%s”. Review the values, then use Save & Apply.').format(profileTitle(profile));
+				statusNode.style.color = 'var(--primary-color-medium, #37c)';
+			};
 
-			profileListOptions.forEach((option) => serverOptions[option].getUIElement('servers').setValue(data[option]));
-			if (data.upstream_mode)
-				upstreamModeOption.getUIElement('global').setValue(data.upstream_mode);
-
-			statusNode.textContent = _('Loaded profile “%s”. Review the values, then use Save & Apply.').format(profileTitle(profile));
-			statusNode.style.color = 'var(--primary-color-medium, #37c)';
+			ui.showModal(_('Preview profile load'), [
+				E('p', {}, _('The following current form values will be replaced by “%s”.').format(profileTitle(profile))),
+				renderProfileDiff(current, target),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
+					E('button', {
+						'class': 'btn cbi-button-positive important',
+						'click': ui.createHandlerFn(this, applyProfile)
+					}, _('Load profile'))
+				])
+			]);
 		};
 
 		const persistProfile = (data, sectionName) => {
@@ -470,7 +550,8 @@ return view.extend({
 			}
 			const data = readFormProfile(profileTitle(profile));
 			ui.showModal(_('Update DNS profile'), [
-				E('p', {}, _('Replace all values stored in “%s” with the current form values?').format(profileTitle(profile))),
+				E('p', {}, _('Review the changes that will be stored in “%s”.').format(profileTitle(profile))),
+				renderProfileDiff(profileData(profile), data),
 				E('div', { 'class': 'right' }, [
 					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
 					E('button', {
@@ -548,51 +629,123 @@ return view.extend({
 			]);
 		};
 
-		const runProfileTest = (profile, data, domain) => {
-			const args = ['--domain', domain, '--upstream-mode', data.upstream_mode || currentUpstreamMode()];
+		const testKindLabel = (kind) => ({
+			bootstrap: _('Bootstrap'),
+			upstream: _('Upstream'),
+			fallback: _('Fallback'),
+			failover: _('Fallback activation')
+		})[kind] || kind;
+
+		const parseTestOutput = (output) => String(output || '').trim().split('\n').filter(Boolean).map((line) => {
+			const fields = line.split('\t');
+			if (fields.length < 10)
+				throw new Error(_('The DNS profile test returned an unsupported result format.'));
+			const numberOrNull = (value) => /^\d+$/.test(value) ? Number(value) : null;
+			return {
+				kind: fields[0],
+				record: fields[1],
+				status: fields[2],
+				success: Number(fields[3]) || 0,
+				attempts: Number(fields[4]) || 0,
+				min: numberOrNull(fields[5]),
+				avg: numberOrNull(fields[6]),
+				max: numberOrNull(fields[7]),
+				server: fields[8],
+				details: fields.slice(9).join(' ')
+			};
+		});
+
+		const executeProfileTest = (profile, data, settings) => {
+			const args = [
+				'--domain', settings.domain,
+				'--attempts', settings.attempts,
+				'--query-type', settings.queryType,
+				'--upstream-mode', data.upstream_mode || currentUpstreamMode()
+			];
 			profileListOptions.forEach((option) => data[option].forEach((value) => args.push('--' + option, value)));
+			return fs.exec('/usr/libexec/dnsproxy-profile-test', args).then((response) => {
+				const output = String(response.stdout || '').trim();
+				if (response.code !== 0)
+					throw new Error(String(response.stderr || output || _('The DNS query failed.')).trim());
+				const rows = parseTestOutput(output);
+				if (!rows.length)
+					throw new Error(_('The DNS profile test returned no results.'));
+				return { profile, rows };
+			});
+		};
 
-			ui.showModal(_('Testing DNS profile'), [
-				E('p', { 'class': 'spinning' }, _('Resolving %s through “%s”…').format(domain, profileTitle(profile)))
+		const milliseconds = (value) => value == null ? '—' : _('%s ms').format(value);
+
+		const testRowStyle = (row, fastest, slowest) => {
+			if (row.status === 'error')
+				return 'background-color:rgba(220,38,38,.14)';
+			if (row.avg === fastest)
+				return 'background-color:rgba(34,197,94,.16)';
+			if (fastest !== slowest && row.avg === slowest)
+				return 'background-color:rgba(234,179,8,.18)';
+			return '';
+		};
+
+		const renderDetailedTest = (profile, settings, resultRows) => {
+			const rows = resultRows.slice().sort((left, right) => {
+				if (left.avg == null && right.avg == null)
+					return right.success - left.success;
+				if (left.avg == null)
+					return 1;
+				if (right.avg == null)
+					return -1;
+				return left.avg - right.avg;
+			});
+			const latencies = rows.map((row) => row.avg).filter((value) => value != null);
+			const fastest = latencies.length ? Math.min(...latencies) : null;
+			const slowest = latencies.length ? Math.max(...latencies) : null;
+			const statusCell = (row) => {
+				if (row.status === 'ok')
+					return E('span', { 'style': 'color:green;font-weight:bold' }, _('OK'));
+				if (row.status === 'partial')
+					return E('span', { 'style': 'color:#b7791f;font-weight:bold' }, _('Partial'));
+				return E('span', { 'style': 'color:red;font-weight:bold' }, _('Failed'));
+			};
+
+			ui.showModal(_('DNS profile test: %s').format(profileTitle(profile)), [
+				E('p', {}, _('%s queries for each selected record type were sent for %s. Bootstrap, Upstream and Fallback endpoints were tested independently; fallback activation used an unavailable primary resolver.').format(settings.attempts, settings.domain)),
+				E('div', { 'class': 'table cbi-section-table' }, [
+					E('div', { 'class': 'tr table-titles' }, [
+						E('div', { 'class': 'th' }, _('Type')),
+						E('div', { 'class': 'th' }, _('Record')),
+						E('div', { 'class': 'th' }, _('Server')),
+						E('div', { 'class': 'th' }, _('Status')),
+						E('div', { 'class': 'th' }, _('Success')),
+						E('div', { 'class': 'th' }, _('Min')),
+						E('div', { 'class': 'th' }, _('Average')),
+						E('div', { 'class': 'th' }, _('Max')),
+						E('div', { 'class': 'th' }, _('Details'))
+					]),
+					...rows.map((row) => E('div', { 'class': 'tr', 'style': testRowStyle(row, fastest, slowest) }, [
+						E('div', { 'class': 'td' }, testKindLabel(row.kind)),
+						E('div', { 'class': 'td' }, row.record),
+						E('div', { 'class': 'td', 'style': 'overflow-wrap:anywhere' }, row.kind === 'failover' ? _('Configured fallback chain') : row.server),
+						E('div', { 'class': 'td' }, statusCell(row)),
+						E('div', { 'class': 'td' }, '%s/%s'.format(row.success, row.attempts)),
+						E('div', { 'class': 'td' }, milliseconds(row.min)),
+						E('div', { 'class': 'td' }, milliseconds(row.avg)),
+						E('div', { 'class': 'td' }, milliseconds(row.max)),
+						E('div', { 'class': 'td' }, row.details || '')
+					]))
+				]),
+				E('p', {}, _('Green is fastest, yellow is slowest, and red indicates complete failure. Results are sorted by average response time.')),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn cbi-button-positive', 'click': ui.hideModal }, _('Close'))
+				])
 			]);
+		};
 
-			return fs.exec('/usr/libexec/dnsproxy-profile-test', args)
-				.then((response) => {
-					const output = String(response.stdout || '').trim();
-					if (response.code !== 0)
-						throw new Error(String(response.stderr || output || _('The DNS query failed.')).trim());
-
-					const rows = output.split('\n').filter(Boolean).map((line) => {
-						const fields = line.split('\t');
-						return [
-							fields[0] === 'fallback' ? _('Fallback') : _('Upstream'),
-							fields[3] || '',
-							fields[1] === 'ok' ? E('span', { 'style': 'color:green;font-weight:bold' }, _('OK')) : E('span', { 'style': 'color:red;font-weight:bold' }, _('Failed')),
-							fields[1] === 'ok' && fields[2] !== '-' ? _('%s ms').format(fields[2]) : '—',
-							fields.slice(4).join(' ') || ''
-						];
-					});
-
-					if (!rows.length)
-						throw new Error(_('The DNS profile test returned no results.'));
-
-					ui.showModal(_('DNS profile test'), [
-						E('p', {}, _('Each server was tested independently by resolving %s through a temporary local DNS Proxy instance.').format(domain)),
-						E('div', { 'class': 'table cbi-section-table' }, [
-							E('div', { 'class': 'tr table-titles' }, [
-								E('div', { 'class': 'th' }, _('Type')),
-								E('div', { 'class': 'th' }, _('Server')),
-								E('div', { 'class': 'th' }, _('Status')),
-								E('div', { 'class': 'th' }, _('Response time')),
-								E('div', { 'class': 'th' }, _('Details'))
-							]),
-							...rows.map((row) => E('div', { 'class': 'tr' }, row.map((cell) => E('div', { 'class': 'td' }, cell))))
-						]),
-						E('div', { 'class': 'right' }, [
-							E('button', { 'class': 'btn cbi-button-positive', 'click': ui.hideModal }, _('Close'))
-						])
-					]);
-				})
+		const runProfileTest = (profile, data, settings) => {
+			ui.showModal(_('Testing DNS profile'), [
+				E('p', { 'class': 'spinning' }, _('Resolving %s through “%s”…').format(settings.domain, profileTitle(profile)))
+			]);
+			return executeProfileTest(profile, data, settings)
+				.then((result) => renderDetailedTest(profile, settings, result.rows))
 				.catch((err) => {
 					ui.showModal(_('DNS profile test failed'), [
 						E('p', { 'style': 'white-space:pre-wrap' }, err.message || String(err)),
@@ -603,25 +756,108 @@ return view.extend({
 				});
 		};
 
-		const testProfile = (profile) => {
-			if (!profile) {
-				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
-				return Promise.resolve();
-			}
-			const data = profileData(profile);
-			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
-			if (!showProfileProblems(result))
-				return Promise.resolve();
+		const compareProfiles = (profiles, settings) => {
+			const progress = E('p', { 'class': 'spinning' });
+			ui.showModal(_('Comparing DNS profiles'), [progress]);
+			const results = [];
+			let chain = Promise.resolve();
+			profiles.forEach((profile, index) => {
+				chain = chain.then(() => {
+					progress.textContent = _('Testing profile %s of %s: %s').format(index + 1, profiles.length, profileTitle(profile));
+					return executeProfileTest(profile, profileData(profile), settings)
+						.then((result) => results.push(result))
+						.catch((error) => results.push({ profile, error: error.message || String(error), rows: [] }));
+				});
+			});
 
+			return chain.then(() => {
+				const summaries = results.map((result) => {
+					const measured = result.rows.filter((row) => row.kind !== 'failover');
+					const successful = measured.filter((row) => row.avg != null);
+					const success = measured.reduce((sum, row) => sum + row.success, 0);
+					const attemptsTotal = measured.reduce((sum, row) => sum + row.attempts, 0);
+					const successWeight = successful.reduce((sum, row) => sum + row.success, 0);
+					const average = successWeight ? Math.round(successful.reduce((sum, row) => sum + row.avg * row.success, 0) / successWeight) : null;
+					const minimums = successful.map((row) => row.min).filter((value) => value != null);
+					const maximums = successful.map((row) => row.max).filter((value) => value != null);
+					const failover = result.rows.filter((row) => row.kind === 'failover');
+					return {
+						name: profileTitle(result.profile),
+						success,
+						attempts: attemptsTotal,
+						errors: attemptsTotal - success,
+						min: minimums.length ? Math.min(...minimums) : null,
+						avg: average,
+						max: maximums.length ? Math.max(...maximums) : null,
+						failover: failover.length ? (failover.every((row) => row.success > 0) ? _('OK') : _('Failed')) : _('Not configured'),
+						details: result.error || ''
+					};
+				}).sort((left, right) => {
+					if (left.avg == null && right.avg == null)
+						return left.errors - right.errors;
+					if (left.avg == null)
+						return 1;
+					if (right.avg == null)
+						return -1;
+					return left.avg - right.avg;
+				});
+				const averages = summaries.map((summary) => summary.avg).filter((value) => value != null);
+				const fastest = averages.length ? Math.min(...averages) : null;
+				const slowest = averages.length ? Math.max(...averages) : null;
+
+				ui.showModal(_('DNS profile comparison'), [
+					E('p', {}, _('All profiles were tested with the same domain, record type and attempt count. Endpoint averages exclude the fallback-activation check.')),
+					E('div', { 'class': 'table cbi-section-table' }, [
+						E('div', { 'class': 'tr table-titles' }, [
+							E('div', { 'class': 'th' }, _('Profile')),
+							E('div', { 'class': 'th' }, _('Success')),
+							E('div', { 'class': 'th' }, _('Errors')),
+							E('div', { 'class': 'th' }, _('Min')),
+							E('div', { 'class': 'th' }, _('Average')),
+							E('div', { 'class': 'th' }, _('Max')),
+							E('div', { 'class': 'th' }, _('Fallback activation')),
+							E('div', { 'class': 'th' }, _('Details'))
+						]),
+						...summaries.map((summary) => E('div', {
+							'class': 'tr',
+							'style': testRowStyle({ status: summary.avg == null ? 'error' : 'ok', avg: summary.avg }, fastest, slowest)
+						}, [
+							E('div', { 'class': 'td' }, summary.name),
+							E('div', { 'class': 'td' }, '%s/%s'.format(summary.success, summary.attempts)),
+							E('div', { 'class': 'td' }, String(summary.errors)),
+							E('div', { 'class': 'td' }, milliseconds(summary.min)),
+							E('div', { 'class': 'td' }, milliseconds(summary.avg)),
+							E('div', { 'class': 'td' }, milliseconds(summary.max)),
+							E('div', { 'class': 'td' }, summary.failover),
+							E('div', { 'class': 'td' }, summary.details)
+						]))
+					]),
+					E('div', { 'class': 'right' }, [
+						E('button', { 'class': 'btn cbi-button-positive', 'click': ui.hideModal }, _('Close'))
+					])
+				]);
+			});
+		};
+
+		const showTestOptions = (title, description, onRun) => {
 			const domainInput = E('input', {
 				'class': 'cbi-input-text',
 				'type': 'text',
-				'value': 'openwrt.org',
+				'value': storedTestDomain(),
 				'placeholder': 'example.com',
 				'maxlength': '254',
 				'autocomplete': 'off',
 				'spellcheck': 'false'
 			});
+			const attemptsSelect = E('select', { 'class': 'cbi-input-select' }, ['1', '3', '5', '10'].map((value) => E('option', {
+				'value': value,
+				'selected': value === '3' ? 'selected' : null
+			}, value)));
+			const queryTypeSelect = E('select', { 'class': 'cbi-input-select' }, [
+				E('option', { 'value': 'A' }, 'A'),
+				E('option', { 'value': 'AAAA' }, 'AAAA'),
+				E('option', { 'value': 'both' }, 'A + AAAA')
+			]);
 			const validationMessage = E('p', { 'style': 'color:var(--error-color, #c00);white-space:pre-wrap' });
 			const startTest = () => {
 				const domain = String(domainInput.value || '').trim();
@@ -631,7 +867,8 @@ return view.extend({
 					domainInput.focus();
 					return Promise.resolve();
 				}
-				return runProfileTest(profile, data, domain);
+				rememberTestDomain(domain);
+				return onRun({ domain, attempts: attemptsSelect.value, queryType: queryTypeSelect.value });
 			};
 
 			domainInput.addEventListener('keydown', (event) => {
@@ -641,11 +878,19 @@ return view.extend({
 				}
 			});
 
-			ui.showModal(_('Test DNS profile'), [
-				E('p', {}, _('Choose the domain used to measure DNS response time. Each configured server will resolve it independently.')),
+			ui.showModal(title, [
+				E('p', {}, description),
 				E('div', { 'class': 'cbi-value' }, [
 					E('label', { 'class': 'cbi-value-title' }, _('Test domain')),
 					E('div', { 'class': 'cbi-value-field' }, domainInput)
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title' }, _('Attempts per record type')),
+					E('div', { 'class': 'cbi-value-field' }, attemptsSelect)
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title' }, _('DNS record type')),
+					E('div', { 'class': 'cbi-value-field' }, queryTypeSelect)
 				]),
 				validationMessage,
 				E('div', { 'class': 'right' }, [
@@ -658,6 +903,20 @@ return view.extend({
 			]);
 			window.setTimeout(() => domainInput.focus(), 0);
 			return Promise.resolve();
+		};
+
+		const testProfile = (profile) => {
+			if (!profile) {
+				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+				return Promise.resolve();
+			}
+			const data = profileData(profile);
+			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
+			if (!showProfileProblems(result))
+				return Promise.resolve();
+			return showTestOptions(_('Test DNS profile'),
+				_('Choose one domain, the number of measurements and DNS record type. The domain is remembered only in this browser.'),
+				(settings) => runProfileTest(profile, data, settings));
 		};
 
 		s.tab('servers', _('Upstreams'));
@@ -694,6 +953,15 @@ return view.extend({
 						'disabled': profiles.length ? null : '',
 						'click': ui.createHandlerFn(this, () => testProfile(selectedProfile()))
 					}, _('Test profile')),
+					E('button', {
+						'class': 'cbi-button cbi-button-action',
+						'disabled': profiles.length > 1 ? null : '',
+						'click': ui.createHandlerFn(this, () => showTestOptions(
+							_('Compare DNS profiles'),
+							_('Every saved profile will be tested sequentially with identical settings. This can take several minutes.'),
+							(settings) => compareProfiles(uci.sections(conf, 'profile'), settings)
+						))
+					}, _('Compare profiles')),
 					E('button', {
 						'class': 'cbi-button cbi-button-add',
 						'click': ui.createHandlerFn(this, promptNewProfile)

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -10,6 +10,8 @@
 
 const conf = 'dnsproxy';
 const instance = 'dnsproxy';
+const profileListOptions = ['bootstrap', 'upstream', 'fallback'];
+const upstreamModes = ['load_balance', 'parallel', 'fastest_addr'];
 
 const callServiceList = rpc.declare({
 	object: 'service',
@@ -39,40 +41,149 @@ function profileTitle(profile) {
 	return profile.label || profile['.name'];
 }
 
-function applyProfile(profileName) {
-	const profile = uci.sections(conf, 'profile').find((item) => item['.name'] === profileName);
+function normalizedList(value) {
+	return L.toArray(value).map((item) => String(item).trim()).filter(Boolean);
+}
 
-	if (!profile) {
-		ui.addNotification(null, E('p', _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
-		return Promise.resolve();
-	}
+function currentUpstreamMode() {
+	return uci.get(conf, 'global', 'upstream_mode') ||
+		(uci.get(conf, 'global', 'fastest_addr') === '1' ? 'fastest_addr' : null) ||
+		(uci.get(conf, 'global', 'all_servers') === '1' ? 'parallel' : 'load_balance');
+}
 
-	const upstreams = L.toArray(profile.upstream).filter(Boolean);
-	if (!upstreams.length) {
-		ui.addNotification(null, E('p', _('The selected DNS profile has no upstream servers.')), 'error');
-		return Promise.resolve();
-	}
+function profileData(profile) {
+	return {
+		label: profileTitle(profile).trim(),
+		bootstrap: normalizedList(profile.bootstrap),
+		upstream: normalizedList(profile.upstream),
+		fallback: normalizedList(profile.fallback),
+		upstream_mode: upstreamModes.includes(profile.upstream_mode) ? profile.upstream_mode : ''
+	};
+}
 
-	['bootstrap', 'upstream', 'fallback'].forEach((option) => {
-		const values = L.toArray(profile[option]).filter(Boolean);
-		uci.set(conf, 'servers', option, values.length ? values : null);
+function listsEqual(left, right) {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function profileMatches(profile, settings) {
+	const data = profileData(profile);
+	const listsMatch = profileListOptions.every((option) => listsEqual(data[option], settings[option]));
+	return listsMatch && (!data.upstream_mode || data.upstream_mode === settings.upstream_mode);
+}
+
+function activeProfile(profiles) {
+	const settings = {
+		bootstrap: normalizedList(uci.get(conf, 'servers', 'bootstrap')),
+		upstream: normalizedList(uci.get(conf, 'servers', 'upstream')),
+		fallback: normalizedList(uci.get(conf, 'servers', 'fallback')),
+		upstream_mode: currentUpstreamMode()
+	};
+
+	return profiles.find((profile) => profileMatches(profile, settings));
+}
+
+function validateServerValue(section_id, value) {
+	if (!value)
+		return true;
+
+	if (value !== value.trim())
+		return _('DNS server values must not begin or end with whitespace.');
+
+	if (value.length > 2048)
+		return _('DNS server values must not exceed 2048 characters.');
+
+	if (/[\u0000-\u001f\u007f]/.test(value))
+		return _('DNS server values must not contain control characters.');
+
+	return true;
+}
+
+function validateUniqueServerValue(listName) {
+	return function (section_id, value) {
+		const result = validateServerValue(section_id, value);
+		if (result !== true)
+			return result;
+
+		const widget = this.getUIElement(section_id);
+		const values = normalizedList(widget ? widget.getValue() : value);
+		if (new Set(values).size !== values.length)
+			return _('Duplicate DNS server in %s.').format(listName);
+
+		return true;
+	};
+}
+
+function analyzeProfile(data, profiles, sectionName) {
+	const errors = [];
+	const warnings = [];
+	const label = String(data.label || '').trim();
+
+	if (!label)
+		errors.push(_('Profile name is required.'));
+	else if (label.length > 64)
+		errors.push(_('Profile name must not exceed 64 characters.'));
+	else if (profiles.some((profile) => profile['.name'] !== sectionName && profileTitle(profile).trim().toLowerCase() === label.toLowerCase()))
+		errors.push(_('Profile names must be unique.'));
+
+	if (!data.upstream.length)
+		errors.push(_('At least one upstream DNS server is required.'));
+
+	profileListOptions.forEach((option) => {
+		const seen = new Set();
+		data[option].forEach((value) => {
+			const result = validateServerValue(null, value);
+			if (result !== true)
+				errors.push(result);
+			if (seen.has(value))
+				errors.push(_('Duplicate DNS server in %s.').format(option));
+			seen.add(value);
+		});
 	});
 
-	ui.showModal(_('Applying DNS profile'), [
-		E('p', { 'class': 'spinning' }, _('Saving “%s” and reloading DNS Proxy…').format(profileTitle(profile)))
-	]);
+	if (data.upstream_mode && !upstreamModes.includes(data.upstream_mode))
+		errors.push(_('Unsupported upstream selection mode.'));
 
-	return uci.save()
-		.then(() => uci.apply())
-		.then(() => {
-			ui.hideModal();
-			ui.addNotification(null, E('p', _('DNS profile “%s” has been applied.').format(profileTitle(profile))), 'info');
-			window.setTimeout(() => window.location.reload(), 800);
-		})
-		.catch((err) => {
-			ui.hideModal();
-			ui.addNotification(null, E('p', _('Failed to apply DNS profile: %s').format(err.message || err)), 'error');
-		});
+	if (!data.bootstrap.length && data.upstream.some((value) => /^(?:https|h3|tls|quic):\/\/[A-Za-z]/i.test(value)))
+		warnings.push(_('No bootstrap DNS server is set. System resolvers will be used for encrypted upstream hostnames.'));
+
+	return { errors, warnings };
+}
+
+function showProfileProblems(result) {
+	result.errors.forEach((message) => ui.addNotification(null, E('p', {}, message), 'error'));
+	result.warnings.forEach((message) => ui.addNotification(null, E('p', {}, message), 'warning'));
+	return result.errors.length === 0;
+}
+
+function setProfileValues(sectionName, data) {
+	uci.set(conf, sectionName, 'label', data.label);
+	profileListOptions.forEach((option) => uci.set(conf, sectionName, option, data[option].length ? data[option] : null));
+	uci.set(conf, sectionName, 'upstream_mode', data.upstream_mode || null);
+}
+
+function exportProfiles(profiles, filename) {
+	const payload = {
+		version: 1,
+		profiles: profiles.map((profile) => profileData(profile))
+	};
+	const blob = new Blob([JSON.stringify(payload, null, 2) + '\n'], { type: 'application/json' });
+	const url = URL.createObjectURL(blob);
+	const link = E('a', { 'href': url, 'download': filename });
+
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function importedProfileData(profile) {
+	return {
+		label: String(profile?.label || '').trim(),
+		bootstrap: normalizedList(profile?.bootstrap),
+		upstream: normalizedList(profile?.upstream),
+		fallback: normalizedList(profile?.fallback),
+		upstream_mode: String(profile?.upstream_mode || '')
+	};
 }
 
 return view.extend({
@@ -100,6 +211,8 @@ return view.extend({
 	render(res) {
 		const isRunning = res[0];
 		const hosts = res[1];
+		const serverOptions = {};
+		let upstreamModeOption;
 
 		let m, s, o, ss, so;
 
@@ -169,23 +282,23 @@ return view.extend({
 		o = s.taboption('main', form.Value, 'udp_buf_size', _('Size of the UDP buffer in bytes. Set 0 use the system default'));
 		o.datatype = 'uinteger';
 
-		o = s.taboption('main', form.ListValue, 'upstream_mode', _('Upstream selection mode'));
-		o.value('load_balance', _('Load balance (one upstream per request)'));
-		o.value('parallel', _('Parallel (first DNS response wins)'));
-	o.value('fastest_addr', _('Fastest address (tests returned IP addresses)'));
-	o.default = 'load_balance';
-	o.rmempty = false;
-	o.description = _('For the lowest DNS response time choose Parallel. Fastest address performs additional IP reachability tests and is a different, slower operation.');
-	o.cfgvalue = function (section_id) {
-		return uci.get(conf, section_id, 'upstream_mode') ||
-			(uci.get(conf, section_id, 'fastest_addr') === '1' ? 'fastest_addr' : null) ||
-			(uci.get(conf, section_id, 'all_servers') === '1' ? 'parallel' : 'load_balance');
-	};
-	o.write = function (section_id, value) {
-		uci.set(conf, section_id, 'upstream_mode', value);
-		uci.unset(conf, section_id, 'all_servers');
-		uci.unset(conf, section_id, 'fastest_addr');
-	};
+		upstreamModeOption = s.taboption('main', form.ListValue, 'upstream_mode', _('Upstream selection mode'));
+		upstreamModeOption.value('load_balance', _('Load balance (one upstream per request)'));
+		upstreamModeOption.value('parallel', _('Parallel (first DNS response wins)'));
+		upstreamModeOption.value('fastest_addr', _('Fastest address (tests returned IP addresses)'));
+		upstreamModeOption.default = 'load_balance';
+		upstreamModeOption.rmempty = false;
+		upstreamModeOption.description = _('For the lowest DNS response time choose Parallel. Fastest address performs additional IP reachability tests and is a different, slower operation.');
+		upstreamModeOption.cfgvalue = function (section_id) {
+			return uci.get(conf, section_id, 'upstream_mode') ||
+				(uci.get(conf, section_id, 'fastest_addr') === '1' ? 'fastest_addr' : null) ||
+				(uci.get(conf, section_id, 'all_servers') === '1' ? 'parallel' : 'load_balance');
+		};
+		upstreamModeOption.write = function (section_id, value) {
+			uci.set(conf, section_id, 'upstream_mode', value);
+			uci.unset(conf, section_id, 'all_servers');
+			uci.unset(conf, section_id, 'fastest_addr');
+		};
 
 		s.tab('cache', _('Cache'));
 
@@ -247,28 +360,282 @@ return view.extend({
 		so = ss.option(form.DynamicList, 'ip_addr', _('Convert matching single IP responses to NXDOMAIN'));
 		so.datatype = "list(ipaddr)";
 
+		const readFormProfile = (label) => ({
+			label: String(label || '').trim(),
+			bootstrap: normalizedList(serverOptions.bootstrap.getUIElement('servers').getValue()),
+			upstream: normalizedList(serverOptions.upstream.getUIElement('servers').getValue()),
+			fallback: normalizedList(serverOptions.fallback.getUIElement('servers').getValue()),
+			upstream_mode: upstreamModeOption.getUIElement('global').getValue() || currentUpstreamMode()
+		});
+
+		const loadProfileIntoForm = (profile, statusNode) => {
+			if (!profile) {
+				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+				return;
+			}
+			const data = profileData(profile);
+			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
+			if (!showProfileProblems(result))
+				return;
+
+			profileListOptions.forEach((option) => serverOptions[option].getUIElement('servers').setValue(data[option]));
+			if (data.upstream_mode)
+				upstreamModeOption.getUIElement('global').setValue(data.upstream_mode);
+
+			statusNode.textContent = _('Loaded profile “%s”. Review the values, then use Save & Apply.').format(profileTitle(profile));
+			statusNode.style.color = 'var(--primary-color-medium, #37c)';
+		};
+
+		const persistProfile = (data, sectionName) => {
+			const profiles = uci.sections(conf, 'profile');
+			const result = analyzeProfile(data, profiles, sectionName);
+			if (!showProfileProblems(result))
+				return Promise.resolve();
+
+			const sid = sectionName || uci.add(conf, 'profile');
+			setProfileValues(sid, data);
+
+			ui.showModal(_('Saving DNS profile'), [
+				E('p', { 'class': 'spinning' }, _('Saving “%s”…').format(data.label))
+			]);
+
+			return uci.save()
+				.then(() => {
+					ui.hideModal();
+					const select = document.querySelector('#dnsproxy-profile-select');
+					const profilesAfterSave = uci.sections(conf, 'profile');
+					if (select) {
+						select.replaceChildren(...profilesAfterSave.map((profile) => E('option', {
+							'value': profile['.name'],
+							'selected': profileTitle(profile).trim().toLowerCase() === data.label.toLowerCase() ? 'selected' : null
+						}, profileTitle(profile))));
+					}
+					ui.addNotification(null, E('p', {}, _('DNS profile “%s” was saved. Current form values were kept; use Save & Apply to activate them.').format(data.label)), 'info');
+				})
+				.catch((err) => {
+					ui.hideModal();
+					ui.addNotification(null, E('p', {}, _('Failed to save DNS profile: %s').format(err.message || err)), 'error');
+				});
+		};
+
+		const promptNewProfile = () => {
+			const input = E('input', {
+				'class': 'cbi-input-text',
+				'type': 'text',
+				'placeholder': _('Profile name'),
+				'maxlength': '64',
+				'autocomplete': 'off'
+			});
+
+			ui.showModal(_('Save current settings as a profile'), [
+				E('p', {}, _('Bootstrap, Upstream, Fallback and the upstream selection mode will be copied from the current form. Active DNS settings are not changed until Save & Apply is used.')),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title' }, _('Profile name')),
+					E('div', { 'class': 'cbi-value-field' }, input)
+				]),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
+					E('button', {
+						'class': 'btn cbi-button-positive important',
+						'click': ui.createHandlerFn(this, () => persistProfile(readFormProfile(input.value)))
+					}, _('Save profile'))
+				])
+			]);
+			window.setTimeout(() => input.focus(), 0);
+		};
+
+		const confirmProfileUpdate = (profile) => {
+			if (!profile) {
+				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+				return;
+			}
+			const data = readFormProfile(profileTitle(profile));
+			ui.showModal(_('Update DNS profile'), [
+				E('p', {}, _('Replace all values stored in “%s” with the current form values?').format(profileTitle(profile))),
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
+					E('button', {
+						'class': 'btn cbi-button-negative important',
+						'click': ui.createHandlerFn(this, () => persistProfile(data, profile['.name']))
+					}, _('Update profile'))
+				])
+			]);
+		};
+
+		const importProfiles = () => {
+			const input = E('input', {
+				'class': 'cbi-input-file',
+				'type': 'file',
+				'accept': 'application/json,.json'
+			});
+
+			const handleImport = () => {
+				const file = input.files?.[0];
+				if (!file) {
+					ui.addNotification(null, E('p', {}, _('Choose a JSON profile file first.')), 'error');
+					return Promise.resolve();
+				}
+				if (file.size > 1024 * 1024) {
+					ui.addNotification(null, E('p', {}, _('The profile file must not exceed 1 MiB.')), 'error');
+					return Promise.resolve();
+				}
+
+				return file.text().then((text) => {
+					const payload = JSON.parse(text);
+					if (payload?.version !== 1 || !Array.isArray(payload.profiles) || !payload.profiles.length || payload.profiles.length > 100)
+						throw new Error(_('Unsupported or empty DNS profile file.'));
+
+					const imported = payload.profiles.map(importedProfileData);
+					const importedLabels = new Set();
+					const existing = uci.sections(conf, 'profile');
+
+					imported.forEach((data) => {
+						const key = data.label.toLowerCase();
+						if (importedLabels.has(key))
+							throw new Error(_('Imported profile names must be unique.'));
+						importedLabels.add(key);
+
+						if (profileListOptions.some((option) => data[option].length > 128))
+							throw new Error(_('A DNS profile list must not contain more than 128 entries.'));
+
+						const match = existing.find((profile) => profileTitle(profile).trim().toLowerCase() === key);
+						const result = analyzeProfile(data, existing, match?.['.name']);
+						if (result.errors.length)
+							throw new Error(result.errors.join('\n'));
+					});
+
+					imported.forEach((data) => {
+						const match = existing.find((profile) => profileTitle(profile).trim().toLowerCase() === data.label.toLowerCase());
+						setProfileValues(match?.['.name'] || uci.add(conf, 'profile'), data);
+					});
+
+					return uci.save();
+				}).then(() => window.location.reload()).catch((err) => {
+					ui.hideModal();
+					ui.addNotification(null, E('p', { 'style': 'white-space:pre-wrap' }, _('Failed to import DNS profiles: %s').format(err.message || err)), 'error');
+				});
+			};
+
+			ui.showModal(_('Import DNS profiles'), [
+				E('p', {}, _('Profiles are merged by name. Matching profiles are replaced; other existing profiles are kept.')),
+				input,
+				E('div', { 'class': 'right' }, [
+					E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Cancel')),
+					E('button', {
+						'class': 'btn cbi-button-positive important',
+						'click': ui.createHandlerFn(this, handleImport)
+					}, _('Import'))
+				])
+			]);
+		};
+
+		const testProfile = (profile) => {
+			if (!profile) {
+				ui.addNotification(null, E('p', {}, _('The selected DNS profile no longer exists. Reload the page and try again.')), 'error');
+				return Promise.resolve();
+			}
+			const data = profileData(profile);
+			const result = analyzeProfile(data, uci.sections(conf, 'profile'), profile['.name']);
+			if (!showProfileProblems(result))
+				return Promise.resolve();
+
+			const args = ['--upstream-mode', data.upstream_mode || currentUpstreamMode()];
+			profileListOptions.forEach((option) => data[option].forEach((value) => args.push('--' + option, value)));
+
+			ui.showModal(_('Testing DNS profile'), [
+				E('p', { 'class': 'spinning' }, _('Resolving openwrt.org through “%s”…').format(profileTitle(profile)))
+			]);
+
+			return fs.exec('/usr/libexec/dnsproxy-profile-test', args)
+				.then((response) => {
+					const output = String(response.stdout || '').trim();
+					if (response.code !== 0)
+						throw new Error(String(response.stderr || output || _('The DNS query failed.')).trim());
+
+					const rows = output.split('\n').filter(Boolean).map((line) => {
+						const fields = line.split('\t');
+						return [
+							fields[0] === 'fallback' ? _('Fallback') : _('Upstream'),
+							fields[3] || '',
+							fields[1] === 'ok' ? E('span', { 'style': 'color:green;font-weight:bold' }, _('OK')) : E('span', { 'style': 'color:red;font-weight:bold' }, _('Failed')),
+							fields[1] === 'ok' && fields[2] !== '-' ? _('%s ms').format(fields[2]) : '—',
+							fields.slice(4).join(' ') || ''
+						];
+					});
+
+					if (!rows.length)
+						throw new Error(_('The DNS profile test returned no results.'));
+
+					ui.showModal(_('DNS profile test'), [
+						E('p', {}, _('Each server was tested independently by resolving openwrt.org through a temporary local DNS Proxy instance.')),
+						E('div', { 'class': 'table cbi-section-table' }, [
+							E('div', { 'class': 'tr table-titles' }, [
+								E('div', { 'class': 'th' }, _('Type')),
+								E('div', { 'class': 'th' }, _('Server')),
+								E('div', { 'class': 'th' }, _('Status')),
+								E('div', { 'class': 'th' }, _('Response time')),
+								E('div', { 'class': 'th' }, _('Details'))
+							]),
+							...rows.map((row) => E('div', { 'class': 'tr' }, row.map((cell) => E('div', { 'class': 'td' }, cell))))
+						]),
+						E('div', { 'class': 'right' }, [
+							E('button', { 'class': 'btn cbi-button-positive', 'click': ui.hideModal }, _('Close'))
+						])
+					]);
+				})
+				.catch((err) => {
+					ui.showModal(_('DNS profile test failed'), [
+						E('p', { 'style': 'white-space:pre-wrap' }, err.message || String(err)),
+						E('div', { 'class': 'right' }, [
+							E('button', { 'class': 'btn', 'click': ui.hideModal }, _('Close'))
+						])
+					]);
+				});
+		};
+
 		s.tab('servers', _('Upstreams'));
 
 		o = s.taboption('servers', form.DummyValue, '_profile_switcher', _('DNS profiles'),
-			_('A profile replaces Bootstrap, Upstream and Fallback lists together, then immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are not included.'));
+			_('Load a reusable Bootstrap, Upstream, Fallback and selection-mode configuration into the form. Review it before using Save & Apply.'));
 		o.renderWidget = function () {
 			const profiles = uci.sections(conf, 'profile');
+			const active = activeProfile(profiles);
+			const status = E('p', {}, active ?
+				_('Active profile: %s').format(profileTitle(active)) :
+				_('Active profile: Custom configuration'));
 			const select = E('select', {
 				'id': 'dnsproxy-profile-select',
 				'class': 'cbi-input-select',
 				'disabled': profiles.length ? null : ''
 			}, profiles.map((profile) => E('option', {
-				'value': profile['.name']
+				'value': profile['.name'],
+				'selected': active && active['.name'] === profile['.name'] ? 'selected' : null
 			}, profileTitle(profile))));
+			const selectedProfile = () => uci.sections(conf, 'profile').find((profile) => profile['.name'] === select.value);
 
 			return E('div', {}, [
+				status,
 				E('div', { 'style': 'display:flex;gap:.75em;align-items:center;flex-wrap:wrap' }, [
 					select,
 					E('button', {
 						'class': 'cbi-button cbi-button-positive important',
 						'disabled': profiles.length ? null : '',
-						'click': ui.createHandlerFn(this, () => applyProfile(select.value))
-					}, _('Apply selected profile'))
+						'click': ui.createHandlerFn(this, () => loadProfileIntoForm(selectedProfile(), status))
+					}, _('Load profile')),
+					E('button', {
+						'class': 'cbi-button cbi-button-action',
+						'disabled': profiles.length ? null : '',
+						'click': ui.createHandlerFn(this, () => testProfile(selectedProfile()))
+					}, _('Test profile')),
+					E('button', {
+						'class': 'cbi-button cbi-button-add',
+						'click': ui.createHandlerFn(this, promptNewProfile)
+					}, _('Save current as profile')),
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'disabled': profiles.length ? null : '',
+						'click': ui.createHandlerFn(this, () => confirmProfileUpdate(selectedProfile()))
+					}, _('Update selected profile'))
 				]),
 				profiles.length ? '' : E('p', {}, _('Create and save a profile in the “DNS profile templates” section below first.'))
 			]);
@@ -277,15 +644,18 @@ return view.extend({
 		o = s.taboption('servers', form.SectionValue, '_servers', form.NamedSection, 'servers', 'homeproxy');
 		ss = o.subsection;
 
-		so = ss.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS Server'));
+		serverOptions.bootstrap = ss.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS Server'));
+		serverOptions.bootstrap.validate = validateUniqueServerValue('bootstrap');
 
-		so = ss.option(form.DynamicList, 'upstream', _('Upstream DNS Server'));
-		so.rmempty = false;
+		serverOptions.upstream = ss.option(form.DynamicList, 'upstream', _('Upstream DNS Server'));
+		serverOptions.upstream.rmempty = false;
+		serverOptions.upstream.validate = validateUniqueServerValue('upstream');
 
-		so = ss.option(form.DynamicList, 'fallback', _('Fallback DNS Server'));
+		serverOptions.fallback = ss.option(form.DynamicList, 'fallback', _('Fallback DNS Server'));
+		serverOptions.fallback.validate = validateUniqueServerValue('fallback');
 
 		o = s.taboption('servers', form.SectionValue, '_profiles', form.GridSection, 'profile', _('DNS profile templates'),
-			_('Create reusable templates here. Applying a template does not modify the template itself.'));
+			_('Create and edit reusable DNS templates. Loading a template does not modify the template itself.'));
 		ss = o.subsection;
 		ss.anonymous = true;
 		ss.addremove = true;
@@ -294,16 +664,64 @@ return view.extend({
 
 		so = ss.option(form.Value, 'label', _('Profile name'));
 		so.rmempty = false;
+		so.validate = function (section_id, value) {
+			const label = String(value || '').trim();
+			if (!label)
+				return _('Profile name is required.');
+			if (label.length > 64)
+				return _('Profile name must not exceed 64 characters.');
+			if (uci.sections(conf, 'profile').some((profile) => profile['.name'] !== section_id && profileTitle(profile).trim().toLowerCase() === label.toLowerCase()))
+				return _('Profile names must be unique.');
+			return true;
+		};
+
+		so = ss.option(form.ListValue, 'upstream_mode', _('Upstream selection mode'));
+		so.value('', _('Keep current mode'));
+		so.value('load_balance', _('Load balance (one upstream per request)'));
+		so.value('parallel', _('Parallel (first DNS response wins)'));
+		so.value('fastest_addr', _('Fastest address (tests returned IP addresses)'));
+		so.rmempty = true;
 
 		so = ss.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS'));
 		so.modalonly = true;
+		so.validate = validateUniqueServerValue('bootstrap');
 
 		so = ss.option(form.DynamicList, 'upstream', _('Upstream DNS'));
 		so.rmempty = false;
 		so.modalonly = true;
+		so.validate = validateUniqueServerValue('upstream');
 
 		so = ss.option(form.DynamicList, 'fallback', _('Fallback DNS'));
 		so.modalonly = true;
+		so.validate = validateUniqueServerValue('fallback');
+
+		const renderProfileEditor = o.render.bind(o);
+		o.render = (...args) => Promise.resolve(renderProfileEditor(...args)).then((node) => E('details', {
+			'class': 'cbi-section'
+		}, [
+			E('summary', { 'style': 'cursor:pointer;font-weight:bold;padding:.5em 0' }, _('Manage DNS profile templates')),
+			E('div', { 'style': 'display:flex;gap:.75em;align-items:center;flex-wrap:wrap;margin:.5em 0 1em' }, [
+				E('button', {
+					'class': 'cbi-button cbi-button-action',
+					'click': ui.createHandlerFn(this, () => {
+						const profiles = uci.sections(conf, 'profile');
+						const selected = document.querySelector('#dnsproxy-profile-select')?.value;
+						const profile = profiles.find((item) => item['.name'] === selected);
+						if (profile)
+							exportProfiles([profile], 'dnsproxy-profile-' + profile['.name'] + '.json');
+					})
+				}, _('Export selected')),
+				E('button', {
+					'class': 'cbi-button cbi-button-action',
+					'click': ui.createHandlerFn(this, () => exportProfiles(uci.sections(conf, 'profile'), 'dnsproxy-profiles.json'))
+				}, _('Export all')),
+				E('button', {
+					'class': 'cbi-button cbi-button-add',
+					'click': ui.createHandlerFn(this, importProfiles)
+				}, _('Import profiles'))
+			]),
+			node
+		]));
 
 		return m.render()
 		.then(L.bind(function(m, nodes) {

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -112,32 +112,6 @@ return view.extend({
 			]);
 		};
 
-		s = m.section(form.NamedSection, '_profile_switcher');
-		s.render = function () {
-			const profiles = uci.sections(conf, 'profile');
-			const select = E('select', {
-				'id': 'dnsproxy-profile-select',
-				'class': 'cbi-input-select',
-				'disabled': profiles.length ? null : ''
-			}, profiles.map((profile) => E('option', {
-				'value': profile['.name']
-			}, profileTitle(profile))));
-
-			return E('div', { 'class': 'cbi-section' }, [
-				E('h3', {}, _('DNS profiles')),
-				E('p', {}, _('A profile replaces Bootstrap, Upstream and Fallback lists together, then immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are not included.')),
-				E('div', { 'style': 'display:flex;gap:.75em;align-items:center;flex-wrap:wrap' }, [
-					select,
-					E('button', {
-						'class': 'cbi-button cbi-button-positive important',
-						'disabled': profiles.length ? null : '',
-						'click': ui.createHandlerFn(this, () => applyProfile(select.value))
-					}, _('Apply selected profile'))
-				]),
-				profiles.length ? '' : E('p', {}, _('Create and save a profile in the “DNS profile templates” section below first.'))
-			]);
-		};
-
 		s = m.section(form.NamedSection, 'global', 'dnsproxy');
 
 		s.tab('main', _('Main'));
@@ -275,6 +249,31 @@ return view.extend({
 
 		s.tab('servers', _('Upstreams'));
 
+		o = s.taboption('servers', form.DummyValue, '_profile_switcher', _('DNS profiles'),
+			_('A profile replaces Bootstrap, Upstream and Fallback lists together, then immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are not included.'));
+		o.renderWidget = function () {
+			const profiles = uci.sections(conf, 'profile');
+			const select = E('select', {
+				'id': 'dnsproxy-profile-select',
+				'class': 'cbi-input-select',
+				'disabled': profiles.length ? null : ''
+			}, profiles.map((profile) => E('option', {
+				'value': profile['.name']
+			}, profileTitle(profile))));
+
+			return E('div', {}, [
+				E('div', { 'style': 'display:flex;gap:.75em;align-items:center;flex-wrap:wrap' }, [
+					select,
+					E('button', {
+						'class': 'cbi-button cbi-button-positive important',
+						'disabled': profiles.length ? null : '',
+						'click': ui.createHandlerFn(this, () => applyProfile(select.value))
+					}, _('Apply selected profile'))
+				]),
+				profiles.length ? '' : E('p', {}, _('Create and save a profile in the “DNS profile templates” section below first.'))
+			]);
+		};
+
 		o = s.taboption('servers', form.SectionValue, '_servers', form.NamedSection, 'servers', 'homeproxy');
 		ss = o.subsection;
 
@@ -285,25 +284,26 @@ return view.extend({
 
 		so = ss.option(form.DynamicList, 'fallback', _('Fallback DNS Server'));
 
-		s = m.section(form.GridSection, 'profile', _('DNS profile templates'),
+		o = s.taboption('servers', form.SectionValue, '_profiles', form.GridSection, 'profile', _('DNS profile templates'),
 			_('Create reusable templates here. Applying a template does not modify the template itself.'));
-		s.anonymous = true;
-		s.addremove = true;
-		s.nodescriptions = true;
-		s.addbtntitle = _('Add DNS profile');
+		ss = o.subsection;
+		ss.anonymous = true;
+		ss.addremove = true;
+		ss.nodescriptions = true;
+		ss.addbtntitle = _('Add DNS profile');
 
-		o = s.option(form.Value, 'label', _('Profile name'));
-		o.rmempty = false;
+		so = ss.option(form.Value, 'label', _('Profile name'));
+		so.rmempty = false;
 
-		o = s.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS'));
-		o.modalonly = true;
+		so = ss.option(form.DynamicList, 'bootstrap', _('Bootstrap DNS'));
+		so.modalonly = true;
 
-		o = s.option(form.DynamicList, 'upstream', _('Upstream DNS'));
-		o.rmempty = false;
-		o.modalonly = true;
+		so = ss.option(form.DynamicList, 'upstream', _('Upstream DNS'));
+		so.rmempty = false;
+		so.modalonly = true;
 
-		o = s.option(form.DynamicList, 'fallback', _('Fallback DNS'));
-		o.modalonly = true;
+		so = ss.option(form.DynamicList, 'fallback', _('Fallback DNS'));
+		so.modalonly = true;
 
 		return m.render()
 		.then(L.bind(function(m, nodes) {

--- a/htdocs/luci-static/resources/view/dnsproxy.js
+++ b/htdocs/luci-static/resources/view/dnsproxy.js
@@ -636,10 +636,10 @@ return view.extend({
 			failover: _('Fallback activation')
 		})[kind] || kind;
 
-		const parseTestOutput = (output) => String(output || '').trim().split('\n').filter(Boolean).map((line) => {
+		const parseTestOutput = (output) => String(output || '').replace(/\r/g, '').replace(/\n+$/, '').split('\n').filter(Boolean).map((line) => {
 			const fields = line.split('\t');
-			if (fields.length < 10)
-				throw new Error(_('The DNS profile test returned an unsupported result format.'));
+			if (fields.length < 9)
+				throw new Error(line || _('The DNS profile test returned an unsupported result format.'));
 			const numberOrNull = (value) => /^\d+$/.test(value) ? Number(value) : null;
 			return {
 				kind: fields[0],
@@ -663,10 +663,7 @@ return view.extend({
 				'--upstream-mode', data.upstream_mode || currentUpstreamMode()
 			];
 			profileListOptions.forEach((option) => data[option].forEach((value) => args.push('--' + option, value)));
-			return fs.exec('/usr/libexec/dnsproxy-profile-test', args).then((response) => {
-				const output = String(response.stdout || '').trim();
-				if (response.code !== 0)
-					throw new Error(String(response.stderr || output || _('The DNS query failed.')).trim());
+			return fs.exec_direct('/usr/libexec/dnsproxy-profile-test', args, 'text', false, true).then((output) => {
 				const rows = parseTestOutput(output);
 				if (!rows.length)
 					throw new Error(_('The DNS profile test returned no results.'));

--- a/po/templates/dnsproxy.pot
+++ b/po/templates/dnsproxy.pot
@@ -1,246 +1,323 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:571
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:677
 msgid "%s ms"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:518
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:711
+msgid ""
+"%s queries for each selected record type were sent for %s. Bootstrap, "
+"Upstream and Fallback endpoints were tested independently; fallback "
+"activation used an unavailable primary resolver."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:599
 msgid "A DNS profile list must not contain more than 128 entries."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:671
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:930
 msgid "Active profile: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:672
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:931
 msgid "Active profile: Custom configuration"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:730
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:998
 msgid "Add DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:293
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:809
+msgid ""
+"All profiles were tested with the same domain, record type and attempt "
+"count. Endpoint averages exclude the fallback-activation check."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:309
 msgid ""
 "Allows HTTP/3 and uses it when it is faster; HTTPS fallback remains "
 "available."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:148
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:164
 msgid "At least one upstream DNS server is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:374
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:888
+msgid "Attempts per record type"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:720
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:816
+msgid "Average"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:390
 msgid "Bogus-NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:752
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:633
+msgid "Bootstrap"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:431
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1020
 msgid "Bootstrap DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:714
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:982
 msgid "Bootstrap DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:450
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:530
 msgid ""
 "Bootstrap, Upstream, Fallback and the upstream selection mode will be copied "
 "from the current form. Active DNS settings are not changed until Save & "
 "Apply is used."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:322
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:338
 msgid "Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:333
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:349
 msgid "Cache size (in bytes)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:456
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:475
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:542
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:652
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:479
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:536
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:556
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:623
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:897
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:494
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:444
+msgid "Changes"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:575
 msgid "Choose a JSON profile file first."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:645
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:918
 msgid ""
-"Choose the domain used to measure DNS response time. Each configured server "
-"will resolve it independently."
+"Choose one domain, the number of measurements and DNS record type. The "
+"domain is remembered only in this browser."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:592
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:600
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:738
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:753
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:836
 msgid "Close"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:243
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:259
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:379
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:960
+msgid "Compare DNS profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:964
+msgid "Compare profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:761
+msgid "Comparing DNS profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:727
+msgid "Configured fallback chain"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:395
 msgid "Convert matching single IP responses to NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:725
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:993
 msgid ""
 "Create and edit reusable DNS templates. Loading a template does not modify "
 "the template itself."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:707
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:975
 msgid ""
 "Create and save a profile in the “DNS profile templates” section below first."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:238
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:462
+msgid "Current form"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:254
 #: root/usr/share/luci/menu.d/luci-app-dnsproxy.json:3
 msgid "DNS Proxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:724
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:808
+msgid "DNS profile comparison"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:992
 msgid "DNS profile templates"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:579
-msgid "DNS profile test"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:597
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:750
 msgid "DNS profile test failed"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:432
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:710
+msgid "DNS profile test: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:512
 msgid ""
 "DNS profile “%s” was saved. Current form values were kept; use Save & Apply "
 "to activate them."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:665
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:924
 msgid "DNS profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:90
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:892
+msgid "DNS record type"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:91
 msgid "DNS server values must not begin or end with whitespace."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:96
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:97
 msgid "DNS server values must not contain control characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:93
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:94
 msgid "DNS server values must not exceed 2048 characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:349
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:365
 msgid "DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:356
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:372
 msgid "DNS64 Prefix"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:587
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:722
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:819
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:302
 msgid "Disable IPv6"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:290
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:306
 msgid "Disable secure TLS cert validation"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:110
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:157
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:111
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:173
 msgid "Duplicate DNS server in %s."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:362
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:378
 msgid "EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:369
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:385
 msgid "EDNS Client Address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:580
-msgid ""
-"Each server was tested independently by resolving %s through a temporary "
-"local DNS Proxy instance."
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:251
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:267
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:327
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:343
 msgid "Enable Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:354
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:370
 msgid "Enable DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:367
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:383
 msgid "Enable EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:292
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:308
 msgid "Enable HTTP/3 for DoH"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:127
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:128
 msgid ""
 "Enter an ASCII domain name, for example example.com. International domains "
 "must use Punycode."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:784
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:814
+msgid "Errors"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:961
+msgid ""
+"Every saved profile will be tested sequentially with identical settings. "
+"This can take several minutes."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1052
 msgid "Export all"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:780
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1048
 msgid "Export selected"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:707
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:792
 msgid "Failed"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:534
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:615
 msgid "Failed to import DNS profiles: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:436
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:516
 msgid "Failed to save DNS profile: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:568
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:635
 msgid "Fallback"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:761
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:433
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1029
 msgid "Fallback DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:721
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:989
 msgid "Fallback DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:307
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:749
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:636
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:818
+msgid "Fallback activation"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:409
+msgid "Fastest address"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:323
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1017
 msgid "Fastest address (tests returned IP addresses)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:310
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:326
 msgid ""
 "For the lowest DNS response time choose Parallel. Fastest address performs "
 "additional IP reachability tests and is a different, slower operation."
@@ -250,279 +327,353 @@ msgstr ""
 msgid "Grant access to LuCI app dnsproxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:546
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:736
+msgid ""
+"Green is fastest, yellow is slowest, and red indicates complete failure. "
+"Results are sorted by average response time."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:627
 msgid "Import"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:538
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:619
 msgid "Import DNS profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:788
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1056
 msgid "Import profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:514
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:595
 msgid "Imported profile names must be unique."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:746
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:410
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1014
 msgid "Keep current mode"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:259
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:275
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:281
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:297
 msgid "Listen ports"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:666
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:925
 msgid ""
 "Load a reusable Bootstrap, Upstream, Fallback and selection-mode "
 "configuration into the form. Review it before using Save & Apply."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:305
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:747
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:407
+msgid "Load balance"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:321
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1015
 msgid "Load balance (one upstream per request)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:691
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:483
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:950
 msgid "Load profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:404
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:471
 msgid "Loaded profile “%s”. Review the values, then use Save & Apply."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:256
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:272
 msgid "Log file path"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:249
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:265
 msgid "Main"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:769
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1037
 msgid "Manage DNS profile templates"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:344
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:721
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:817
+msgid "Max"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:360
 msgid "Max TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:339
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:719
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:815
+msgid "Min"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:355
 msgid "Min TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:166
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:182
 msgid ""
 "No bootstrap DNS server is set. System resolvers will be used for encrypted "
 "upstream hostnames."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:440
+msgid "No differences."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:792
+msgid "Not configured"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:704
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:792
 msgid "OK"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:329
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:345
 msgid "Optimistic Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:306
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:748
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:425
+msgid "Order changed"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:408
+msgid "Parallel"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:322
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1016
 msgid "Parallel (first DNS response wins)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:444
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:452
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:732
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:706
+msgid "Partial"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:475
+msgid "Preview profile load"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:812
+msgid "Profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:524
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:532
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1000
 msgid "Profile name"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:141
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:737
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:157
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1005
 msgid "Profile name is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:143
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:739
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:159
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1007
 msgid "Profile name must not exceed 64 characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:145
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:741
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:161
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1009
 msgid "Profile names must be unique."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:539
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:620
 msgid ""
 "Profiles are merged by name. Matching profiles are replaced; other existing "
 "profiles are kept."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:298
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:314
 msgid "Ratelimit (requests per second)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:715
+msgid "Record"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:304
 msgid "Refuse <code>ANY</code> requests"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:473
-msgid "Replace all values stored in “%s” with the current form values?"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:556
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:745
 msgid "Resolving %s through “%s”…"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:586
-msgid "Response time"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:553
+msgid "Review the changes that will be stored in “%s”."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:656
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:901
 msgid "Run test"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:225
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:241
 msgid "SERVER NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:223
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:239
 msgid "SERVER RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:700
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:968
 msgid "Save current as profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:449
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:529
 msgid "Save current settings as a profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:460
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:540
 msgid "Save profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:417
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:497
 msgid "Saving DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:418
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:498
 msgid "Saving “%s”…"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:584
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:716
 msgid "Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:301
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:443
+msgid "Setting"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:317
 msgid "Size of the UDP buffer in bytes. Set 0 use the system default"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:585
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:717
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:644
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:718
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:813
+msgid "Success"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:917
 msgid "Test DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:647
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:884
 msgid "Test domain"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:130
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:131
 msgid "Test domain contains an invalid DNS label."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:121
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:122
 msgid "Test domain is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:124
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:125
 msgid "Test domain must not exceed 253 characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:696
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:955
 msgid "Test profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:555
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:744
 msgid "Testing DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:577
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:766
+msgid "Testing profile %s of %s: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:642
+msgid "The DNS profile test returned an unsupported result format."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:672
 msgid "The DNS profile test returned no results."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:563
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:669
 msgid "The DNS query failed."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:498
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:476
+msgid "The following current form values will be replaced by “%s”."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:579
 msgid "The profile file must not exceed 1 MiB."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:392
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:468
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:608
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:455
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:548
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:910
 msgid ""
 "The selected DNS profile no longer exists. Reload the page and try again."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:295
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:311
 msgid "Timeout for queries to remote upstream (default: 10s)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:583
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:714
 msgid "Type"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:505
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:586
 msgid "Unsupported or empty DNS profile file."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:163
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:179
 msgid "Unsupported upstream selection mode."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:472
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:552
 msgid "Update DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:479
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:560
 msgid "Update profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:705
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:973
 msgid "Update selected profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:568
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:634
 msgid "Upstream"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:756
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:432
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1024
 msgid "Upstream DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:717
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:985
 msgid "Upstream DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:304
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:745
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:320
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:430
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:1013
 msgid "Upstream selection mode"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:663
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:922
 msgid "Upstreams"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:254
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:270
 msgid "Verbose"
 msgstr ""

--- a/po/templates/dnsproxy.pot
+++ b/po/templates/dnsproxy.pot
@@ -1,155 +1,250 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:187
-msgid "Bogus-NXDOMAIN"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:128
+msgid ""
+"A profile replaces Bootstrap, Upstream and Fallback lists together, then "
+"immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are "
+"not included."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:200
-msgid "Bootstrap DNS Server"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:293
+msgid "Add DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:187
+msgid ""
+"Allows HTTP/3 and uses it when it is faster; HTTPS fallback remains "
+"available."
 msgstr ""
 
 #: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:135
+msgid "Apply selected profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:61
+msgid "Applying DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:268
+msgid "Bogus-NXDOMAIN"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:298
+msgid "Bootstrap DNS"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:281
+msgid "Bootstrap DNS Server"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:216
 msgid "Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:146
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:227
 msgid "Cache size (in bytes)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:70
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:111
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:192
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:273
 msgid "Convert matching single IP responses to NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:65
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:137
+msgid ""
+"Create and save a profile in the “DNS profile templates” section below first."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:289
+msgid ""
+"Create reusable templates here. Applying a template does not modify the "
+"template itself."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:106
 #: applications/luci-app-dnsproxy/root/usr/share/luci/menu.d/luci-app-dnsproxy.json:3
 msgid "DNS Proxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:162
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
+msgid "DNS profile templates"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:69
+msgid "DNS profile “%s” has been applied."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:127
+msgid "DNS profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:243
 msgid "DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:169
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:250
 msgid "DNS64 Prefix"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:113
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:180
 msgid "Disable IPv6"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:117
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:184
 msgid "Disable secure TLS cert validation"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:119
-msgid "DoH uses H3 first"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:175
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:256
 msgid "EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:182
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:263
 msgid "EDNS Client Address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:78
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:145
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:140
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:221
 msgid "Enable Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:167
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:248
 msgid "Enable DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:180
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:261
 msgid "Enable EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:205
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:186
+msgid "Enable HTTP/3 for DoH"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:74
+msgid "Failed to apply DNS profile: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:305
+msgid "Fallback DNS"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
 msgid "Fallback DNS Server"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:201
+msgid "Fastest address (tests returned IP addresses)"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:204
+msgid ""
+"For the lowest DNS response time choose Parallel. Fastest address performs "
+"additional IP reachability tests and is a different, slower operation."
 msgstr ""
 
 #: applications/luci-app-dnsproxy/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json:3
 msgid "Grant access to LuCI app dnsproxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:86
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:153
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:108
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:175
 msgid "Listen ports"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:83
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:199
+msgid "Load balance (one upstream per request)"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:150
 msgid "Log file path"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:76
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:143
 msgid "Main"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:157
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:238
 msgid "Max TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:152
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:233
 msgid "Min TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:142
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:223
 msgid "Optimistic Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:130
-msgid "Parallel queries all upstream"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:200
+msgid "Parallel (first DNS response wins)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:124
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:295
+msgid "Profile name"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:192
 msgid "Ratelimit (requests per second)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:115
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:182
 msgid "Refuse <code>ANY</code> requests"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:132
-msgid "Respond to A or AAAA requests only with the fastest IP address"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:54
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:95
 msgid "SERVER NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:52
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:93
 msgid "SERVER RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:127
-msgid "Size of the UDP buffer in bytes. Set 0 use the system default"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:121
-msgid "Timeout for queries to remote upstream (default: 10s)"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:202
-msgid "Upstream DNS Server"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:62
+msgid "Saving “%s” and reloading DNS Proxy…"
 msgstr ""
 
 #: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:195
+msgid "Size of the UDP buffer in bytes. Set 0 use the system default"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:52
+msgid "The selected DNS profile has no upstream servers."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:46
+msgid ""
+"The selected DNS profile no longer exists. Reload the page and try again."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:189
+msgid "Timeout for queries to remote upstream (default: 10s)"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:301
+msgid "Upstream DNS"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:283
+msgid "Upstream DNS Server"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:198
+msgid "Upstream selection mode"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:276
 msgid "Upstreams"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:81
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:148
 msgid "Verbose"
 msgstr ""

--- a/po/templates/dnsproxy.pot
+++ b/po/templates/dnsproxy.pot
@@ -1,121 +1,128 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:561
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:571
 msgid "%s ms"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:499
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:518
 msgid "A DNS profile list must not contain more than 128 entries."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:604
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:671
 msgid "Active profile: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:605
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:672
 msgid "Active profile: Custom configuration"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:663
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:730
 msgid "Add DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:274
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:293
 msgid ""
 "Allows HTTP/3 and uses it when it is faster; HTTPS fallback remains "
 "available."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:129
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:148
 msgid "At least one upstream DNS server is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:355
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:374
 msgid "Bogus-NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:685
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:752
 msgid "Bootstrap DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:647
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:714
 msgid "Bootstrap DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:431
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:450
 msgid ""
 "Bootstrap, Upstream, Fallback and the upstream selection mode will be copied "
 "from the current form. Active DNS settings are not changed until Save & "
 "Apply is used."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:303
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:322
 msgid "Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:314
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:333
 msgid "Cache size (in bytes)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:437
 #: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:456
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:523
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:475
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:542
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:652
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:475
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:494
 msgid "Choose a JSON profile file first."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:582
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:590
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:645
+msgid ""
+"Choose the domain used to measure DNS response time. Each configured server "
+"will resolve it independently."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:592
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:600
 msgid "Close"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:224
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:243
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:360
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:379
 msgid "Convert matching single IP responses to NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:658
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:725
 msgid ""
 "Create and edit reusable DNS templates. Loading a template does not modify "
 "the template itself."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:640
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:707
 msgid ""
 "Create and save a profile in the “DNS profile templates” section below first."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:219
-#: applications/luci-app-dnsproxy/root/usr/share/luci/menu.d/luci-app-dnsproxy.json:3
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:238
+#: root/usr/share/luci/menu.d/luci-app-dnsproxy.json:3
 msgid "DNS Proxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:657
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:724
 msgid "DNS profile templates"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:569
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:579
 msgid "DNS profile test"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:587
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:597
 msgid "DNS profile test failed"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:413
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:432
 msgid ""
 "DNS profile “%s” was saved. Current form values were kept; use Save & Apply "
 "to activate them."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:598
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:665
 msgid "DNS profiles"
 msgstr ""
 
@@ -131,361 +138,391 @@ msgstr ""
 msgid "DNS server values must not exceed 2048 characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:330
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:349
 msgid "DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:337
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:356
 msgid "DNS64 Prefix"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:577
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:587
 msgid "Details"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:267
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
 msgid "Disable IPv6"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:271
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:290
 msgid "Disable secure TLS cert validation"
 msgstr ""
 
 #: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:110
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:138
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:157
 msgid "Duplicate DNS server in %s."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:343
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:362
 msgid "EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:350
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:369
 msgid "EDNS Client Address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:580
 msgid ""
-"Each server was tested independently by resolving openwrt.org through a "
-"temporary local DNS Proxy instance."
+"Each server was tested independently by resolving %s through a temporary "
+"local DNS Proxy instance."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:232
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:251
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:308
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:327
 msgid "Enable Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:335
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:354
 msgid "Enable DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:348
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:367
 msgid "Enable EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:273
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:292
 msgid "Enable HTTP/3 for DoH"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:717
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:127
+msgid ""
+"Enter an ASCII domain name, for example example.com. International domains "
+"must use Punycode."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:784
 msgid "Export all"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:713
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:780
 msgid "Export selected"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:560
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
 msgid "Failed"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:515
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:534
 msgid "Failed to import DNS profiles: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:417
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:436
 msgid "Failed to save DNS profile: %s"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:558
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:568
 msgid "Fallback"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:694
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:761
 msgid "Fallback DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:654
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:721
 msgid "Fallback DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:682
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:307
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:749
 msgid "Fastest address (tests returned IP addresses)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:291
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:310
 msgid ""
 "For the lowest DNS response time choose Parallel. Fastest address performs "
 "additional IP reachability tests and is a different, slower operation."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json:3
+#: root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json:3
 msgid "Grant access to LuCI app dnsproxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:527
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:546
 msgid "Import"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:519
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:538
 msgid "Import DNS profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:721
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:788
 msgid "Import profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:495
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:514
 msgid "Imported profile names must be unique."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:679
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:746
 msgid "Keep current mode"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:240
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:259
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:262
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:281
 msgid "Listen ports"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:599
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:666
 msgid ""
 "Load a reusable Bootstrap, Upstream, Fallback and selection-mode "
 "configuration into the form. Review it before using Save & Apply."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:680
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:305
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:747
 msgid "Load balance (one upstream per request)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:624
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:691
 msgid "Load profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:385
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:404
 msgid "Loaded profile “%s”. Review the values, then use Save & Apply."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:237
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:256
 msgid "Log file path"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:230
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:249
 msgid "Main"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:702
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:769
 msgid "Manage DNS profile templates"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:325
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:344
 msgid "Max TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:320
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:339
 msgid "Min TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:147
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:166
 msgid ""
 "No bootstrap DNS server is set. System resolvers will be used for encrypted "
 "upstream hostnames."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:560
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
 msgid "OK"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:310
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:329
 msgid "Optimistic Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:287
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:681
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:306
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:748
 msgid "Parallel (first DNS response wins)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:425
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:433
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:665
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:444
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:452
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:732
 msgid "Profile name"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:122
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:670
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:141
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:737
 msgid "Profile name is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:124
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:672
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:143
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:739
 msgid "Profile name must not exceed 64 characters."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:126
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:674
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:145
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:741
 msgid "Profile names must be unique."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:520
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:539
 msgid ""
 "Profiles are merged by name. Matching profiles are replaced; other existing "
 "profiles are kept."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:279
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:298
 msgid "Ratelimit (requests per second)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:269
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
 msgid "Refuse <code>ANY</code> requests"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:454
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:473
 msgid "Replace all values stored in “%s” with the current form values?"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:546
-msgid "Resolving openwrt.org through “%s”…"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:556
+msgid "Resolving %s through “%s”…"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:576
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:586
 msgid "Response time"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:206
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:656
+msgid "Run test"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:225
 msgid "SERVER NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:204
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:223
 msgid "SERVER RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:633
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:700
 msgid "Save current as profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:430
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:449
 msgid "Save current settings as a profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:441
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:460
 msgid "Save profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:398
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:417
 msgid "Saving DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:399
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:418
 msgid "Saving “%s”…"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:574
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:584
 msgid "Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:282
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:301
 msgid "Size of the UDP buffer in bytes. Set 0 use the system default"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:575
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:585
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:629
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:644
+msgid "Test DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:647
+msgid "Test domain"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:130
+msgid "Test domain contains an invalid DNS label."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:121
+msgid "Test domain is required."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:124
+msgid "Test domain must not exceed 253 characters."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:696
 msgid "Test profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:545
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:555
 msgid "Testing DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:567
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:577
 msgid "The DNS profile test returned no results."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:553
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:563
 msgid "The DNS query failed."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:479
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:498
 msgid "The profile file must not exceed 1 MiB."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:373
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:449
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:534
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:392
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:468
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:608
 msgid ""
 "The selected DNS profile no longer exists. Reload the page and try again."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:276
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:295
 msgid "Timeout for queries to remote upstream (default: 10s)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:573
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:583
 msgid "Type"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:486
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:505
 msgid "Unsupported or empty DNS profile file."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:144
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:163
 msgid "Unsupported upstream selection mode."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:453
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:472
 msgid "Update DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:460
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:479
 msgid "Update profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:638
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:705
 msgid "Update selected profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:558
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:568
 msgid "Upstream"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:689
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:756
 msgid "Upstream DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:650
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:717
 msgid "Upstream DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:285
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:678
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:304
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:745
 msgid "Upstream selection mode"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:596
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:663
 msgid "Upstreams"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:235
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:254
 msgid "Verbose"
 msgstr ""

--- a/po/templates/dnsproxy.pot
+++ b/po/templates/dnsproxy.pot
@@ -1,148 +1,233 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:128
-msgid ""
-"A profile replaces Bootstrap, Upstream and Fallback lists together, then "
-"immediately reloads DNS Proxy. Unsaved changes elsewhere on this page are "
-"not included."
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:561
+msgid "%s ms"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:293
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:499
+msgid "A DNS profile list must not contain more than 128 entries."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:604
+msgid "Active profile: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:605
+msgid "Active profile: Custom configuration"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:663
 msgid "Add DNS profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:187
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:274
 msgid ""
 "Allows HTTP/3 and uses it when it is faster; HTTPS fallback remains "
 "available."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:135
-msgid "Apply selected profile"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:129
+msgid "At least one upstream DNS server is required."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:61
-msgid "Applying DNS profile"
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:268
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:355
 msgid "Bogus-NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:298
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:685
 msgid "Bootstrap DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:281
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:647
 msgid "Bootstrap DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:216
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:431
+msgid ""
+"Bootstrap, Upstream, Fallback and the upstream selection mode will be copied "
+"from the current form. Active DNS settings are not changed until Save & "
+"Apply is used."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:303
 msgid "Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:227
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:314
 msgid "Cache size (in bytes)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:111
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:437
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:456
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:523
+msgid "Cancel"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:475
+msgid "Choose a JSON profile file first."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:582
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:590
+msgid "Close"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:224
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:273
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:360
 msgid "Convert matching single IP responses to NXDOMAIN"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:137
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:658
+msgid ""
+"Create and edit reusable DNS templates. Loading a template does not modify "
+"the template itself."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:640
 msgid ""
 "Create and save a profile in the “DNS profile templates” section below first."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:289
-msgid ""
-"Create reusable templates here. Applying a template does not modify the "
-"template itself."
-msgstr ""
-
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:106
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:219
 #: applications/luci-app-dnsproxy/root/usr/share/luci/menu.d/luci-app-dnsproxy.json:3
 msgid "DNS Proxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:657
 msgid "DNS profile templates"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:69
-msgid "DNS profile “%s” has been applied."
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:569
+msgid "DNS profile test"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:127
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:587
+msgid "DNS profile test failed"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:413
+msgid ""
+"DNS profile “%s” was saved. Current form values were kept; use Save & Apply "
+"to activate them."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:598
 msgid "DNS profiles"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:243
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:90
+msgid "DNS server values must not begin or end with whitespace."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:96
+msgid "DNS server values must not contain control characters."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:93
+msgid "DNS server values must not exceed 2048 characters."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:330
 msgid "DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:250
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:337
 msgid "DNS64 Prefix"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:180
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:577
+msgid "Details"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:267
 msgid "Disable IPv6"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:184
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:271
 msgid "Disable secure TLS cert validation"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:256
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:110
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:138
+msgid "Duplicate DNS server in %s."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:343
 msgid "EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:263
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:350
 msgid "EDNS Client Address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:145
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:570
+msgid ""
+"Each server was tested independently by resolving openwrt.org through a "
+"temporary local DNS Proxy instance."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:232
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:221
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:308
 msgid "Enable Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:248
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:335
 msgid "Enable DNS64"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:261
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:348
 msgid "Enable EDNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:186
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:273
 msgid "Enable HTTP/3 for DoH"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:74
-msgid "Failed to apply DNS profile: %s"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:717
+msgid "Export all"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:305
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:713
+msgid "Export selected"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:560
+msgid "Failed"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:515
+msgid "Failed to import DNS profiles: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:417
+msgid "Failed to save DNS profile: %s"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:558
+msgid "Fallback"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:694
 msgid "Fallback DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:654
 msgid "Fallback DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:201
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:288
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:682
 msgid "Fastest address (tests returned IP addresses)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:204
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:291
 msgid ""
 "For the lowest DNS response time choose Parallel. Fastest address performs "
 "additional IP reachability tests and is a different, slower operation."
@@ -152,99 +237,255 @@ msgstr ""
 msgid "Grant access to LuCI app dnsproxy"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:153
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:527
+msgid "Import"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:519
+msgid "Import DNS profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:721
+msgid "Import profiles"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:495
+msgid "Imported profile names must be unique."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:679
+msgid "Keep current mode"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:240
 msgid "Listen address"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:175
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:262
 msgid "Listen ports"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:199
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:599
+msgid ""
+"Load a reusable Bootstrap, Upstream, Fallback and selection-mode "
+"configuration into the form. Review it before using Save & Apply."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:286
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:680
 msgid "Load balance (one upstream per request)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:150
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:624
+msgid "Load profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:385
+msgid "Loaded profile “%s”. Review the values, then use Save & Apply."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:237
 msgid "Log file path"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:143
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:230
 msgid "Main"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:238
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:702
+msgid "Manage DNS profile templates"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:325
 msgid "Max TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:233
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:320
 msgid "Min TTL value for DNS entries, in seconds"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:223
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:147
+msgid ""
+"No bootstrap DNS server is set. System resolvers will be used for encrypted "
+"upstream hostnames."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:560
+msgid "OK"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:310
 msgid "Optimistic Cache"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:200
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:287
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:681
 msgid "Parallel (first DNS response wins)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:295
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:425
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:433
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:665
 msgid "Profile name"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:192
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:122
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:670
+msgid "Profile name is required."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:124
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:672
+msgid "Profile name must not exceed 64 characters."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:126
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:674
+msgid "Profile names must be unique."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:520
+msgid ""
+"Profiles are merged by name. Matching profiles are replaced; other existing "
+"profiles are kept."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:279
 msgid "Ratelimit (requests per second)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:182
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:269
 msgid "Refuse <code>ANY</code> requests"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:95
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:454
+msgid "Replace all values stored in “%s” with the current form values?"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:546
+msgid "Resolving openwrt.org through “%s”…"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:576
+msgid "Response time"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:206
 msgid "SERVER NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:93
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:204
 msgid "SERVER RUNNING"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:62
-msgid "Saving “%s” and reloading DNS Proxy…"
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:633
+msgid "Save current as profile"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:195
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:430
+msgid "Save current settings as a profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:441
+msgid "Save profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:398
+msgid "Saving DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:399
+msgid "Saving “%s”…"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:574
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:282
 msgid "Size of the UDP buffer in bytes. Set 0 use the system default"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:52
-msgid "The selected DNS profile has no upstream servers."
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:575
+msgid "Status"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:46
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:629
+msgid "Test profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:545
+msgid "Testing DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:567
+msgid "The DNS profile test returned no results."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:553
+msgid "The DNS query failed."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:479
+msgid "The profile file must not exceed 1 MiB."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:373
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:449
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:534
 msgid ""
 "The selected DNS profile no longer exists. Reload the page and try again."
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:189
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:276
 msgid "Timeout for queries to remote upstream (default: 10s)"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:301
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:573
+msgid "Type"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:486
+msgid "Unsupported or empty DNS profile file."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:144
+msgid "Unsupported upstream selection mode."
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:453
+msgid "Update DNS profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:460
+msgid "Update profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:638
+msgid "Update selected profile"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:558
+msgid "Upstream"
+msgstr ""
+
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:689
 msgid "Upstream DNS"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:283
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:650
 msgid "Upstream DNS Server"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:198
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:285
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:678
 msgid "Upstream selection mode"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:276
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:596
 msgid "Upstreams"
 msgstr ""
 
-#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:148
+#: applications/luci-app-dnsproxy/htdocs/luci-static/resources/view/dnsproxy.js:235
 msgid "Verbose"
 msgstr ""

--- a/root/etc/uci-defaults/99-luci-app-dnsproxy-defaults
+++ b/root/etc/uci-defaults/99-luci-app-dnsproxy-defaults
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+add_cloudflare_profile() {
+	uci set dnsproxy.cloudflare='profile'
+	uci set dnsproxy.cloudflare.label='Cloudflare DoH'
+	uci add_list dnsproxy.cloudflare.bootstrap='1.1.1.1:53'
+	uci add_list dnsproxy.cloudflare.bootstrap='1.0.0.1:53'
+	uci add_list dnsproxy.cloudflare.upstream='https://cloudflare-dns.com/dns-query'
+	uci add_list dnsproxy.cloudflare.fallback='https://dns.quad9.net/dns-query'
+}
+
+add_quad9_profile() {
+	uci set dnsproxy.quad9='profile'
+	uci set dnsproxy.quad9.label='Quad9 DoH'
+	uci add_list dnsproxy.quad9.bootstrap='9.9.9.9:53'
+	uci add_list dnsproxy.quad9.bootstrap='149.112.112.112:53'
+	uci add_list dnsproxy.quad9.upstream='https://dns.quad9.net/dns-query'
+	uci add_list dnsproxy.quad9.fallback='https://cloudflare-dns.com/dns-query'
+}
+
+add_google_profile() {
+	uci set dnsproxy.google='profile'
+	uci set dnsproxy.google.label='Google DoH'
+	uci add_list dnsproxy.google.bootstrap='8.8.8.8:53'
+	uci add_list dnsproxy.google.bootstrap='8.8.4.4:53'
+	uci add_list dnsproxy.google.upstream='https://dns.google/dns-query'
+	uci add_list dnsproxy.google.fallback='https://cloudflare-dns.com/dns-query'
+}
+
+add_fast_mixed_profile() {
+	uci set dnsproxy.fast_mixed='profile'
+	uci set dnsproxy.fast_mixed.label='Fast mixed DoH'
+	uci add_list dnsproxy.fast_mixed.bootstrap='1.1.1.1:53'
+	uci add_list dnsproxy.fast_mixed.bootstrap='9.9.9.9:53'
+	uci add_list dnsproxy.fast_mixed.bootstrap='8.8.8.8:53'
+	uci add_list dnsproxy.fast_mixed.upstream='https://cloudflare-dns.com/dns-query'
+	uci add_list dnsproxy.fast_mixed.upstream='https://dns.quad9.net/dns-query'
+	uci add_list dnsproxy.fast_mixed.fallback='https://dns.google/dns-query'
+}
+
+uci -q get dnsproxy.cloudflare >/dev/null || add_cloudflare_profile
+uci -q get dnsproxy.quad9 >/dev/null || add_quad9_profile
+uci -q get dnsproxy.google >/dev/null || add_google_profile
+uci -q get dnsproxy.fast_mixed >/dev/null || add_fast_mixed_profile
+
+mode="$(uci -q get dnsproxy.global.upstream_mode)"
+
+if [ -z "$mode" ]; then
+	if [ "$(uci -q get dnsproxy.global.fastest_addr)" = '1' ]; then
+		uci set dnsproxy.global.upstream_mode='fastest_addr'
+	elif [ "$(uci -q get dnsproxy.global.all_servers)" = '1' ]; then
+		uci set dnsproxy.global.upstream_mode='parallel'
+	else
+		uci set dnsproxy.global.upstream_mode='load_balance'
+	fi
+fi
+
+uci -q delete dnsproxy.global.all_servers
+uci -q delete dnsproxy.global.fastest_addr
+uci commit dnsproxy
+
+exit 0

--- a/root/etc/uci-defaults/99-luci-app-dnsproxy-defaults
+++ b/root/etc/uci-defaults/99-luci-app-dnsproxy-defaults
@@ -7,6 +7,7 @@ add_cloudflare_profile() {
 	uci add_list dnsproxy.cloudflare.bootstrap='1.0.0.1:53'
 	uci add_list dnsproxy.cloudflare.upstream='https://cloudflare-dns.com/dns-query'
 	uci add_list dnsproxy.cloudflare.fallback='https://dns.quad9.net/dns-query'
+	uci set dnsproxy.cloudflare.upstream_mode='load_balance'
 }
 
 add_quad9_profile() {
@@ -16,6 +17,7 @@ add_quad9_profile() {
 	uci add_list dnsproxy.quad9.bootstrap='149.112.112.112:53'
 	uci add_list dnsproxy.quad9.upstream='https://dns.quad9.net/dns-query'
 	uci add_list dnsproxy.quad9.fallback='https://cloudflare-dns.com/dns-query'
+	uci set dnsproxy.quad9.upstream_mode='load_balance'
 }
 
 add_google_profile() {
@@ -25,6 +27,7 @@ add_google_profile() {
 	uci add_list dnsproxy.google.bootstrap='8.8.4.4:53'
 	uci add_list dnsproxy.google.upstream='https://dns.google/dns-query'
 	uci add_list dnsproxy.google.fallback='https://cloudflare-dns.com/dns-query'
+	uci set dnsproxy.google.upstream_mode='load_balance'
 }
 
 add_fast_mixed_profile() {
@@ -36,12 +39,18 @@ add_fast_mixed_profile() {
 	uci add_list dnsproxy.fast_mixed.upstream='https://cloudflare-dns.com/dns-query'
 	uci add_list dnsproxy.fast_mixed.upstream='https://dns.quad9.net/dns-query'
 	uci add_list dnsproxy.fast_mixed.fallback='https://dns.google/dns-query'
+	uci set dnsproxy.fast_mixed.upstream_mode='parallel'
 }
 
 uci -q get dnsproxy.cloudflare >/dev/null || add_cloudflare_profile
 uci -q get dnsproxy.quad9 >/dev/null || add_quad9_profile
 uci -q get dnsproxy.google >/dev/null || add_google_profile
 uci -q get dnsproxy.fast_mixed >/dev/null || add_fast_mixed_profile
+
+uci -q get dnsproxy.cloudflare.upstream_mode >/dev/null || uci set dnsproxy.cloudflare.upstream_mode='load_balance'
+uci -q get dnsproxy.quad9.upstream_mode >/dev/null || uci set dnsproxy.quad9.upstream_mode='load_balance'
+uci -q get dnsproxy.google.upstream_mode >/dev/null || uci set dnsproxy.google.upstream_mode='load_balance'
+uci -q get dnsproxy.fast_mixed.upstream_mode >/dev/null || uci set dnsproxy.fast_mixed.upstream_mode='parallel'
 
 mode="$(uci -q get dnsproxy.global.upstream_mode)"
 

--- a/root/usr/libexec/dnsproxy-profile-test
+++ b/root/usr/libexec/dnsproxy-profile-test
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+set -u
+
+tmpdir="/tmp/dnsproxy-profile-test.$$"
+bootstrap_file="$tmpdir/bootstrap"
+upstream_file="$tmpdir/upstream"
+fallback_file="$tmpdir/fallback"
+log_file="$tmpdir/dnsproxy.log"
+pid=''
+
+cleanup() {
+	if [ -n "$pid" ]; then
+		kill "$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+	fi
+	rm -rf "$tmpdir"
+}
+
+trap cleanup EXIT INT TERM
+
+mkdir -m 0700 "$tmpdir" || exit 1
+: > "$bootstrap_file"
+: > "$upstream_file"
+: > "$fallback_file"
+
+mode='load_balance'
+count=0
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--upstream-mode)
+			[ "$#" -ge 2 ] || exit 2
+			case "$2" in
+				load_balance|parallel|fastest_addr) mode="$2" ;;
+				*) exit 2 ;;
+			esac
+			shift 2
+			;;
+		--bootstrap|--upstream|--fallback)
+			[ "$#" -ge 2 ] || exit 2
+			count=$((count + 1))
+			[ "$count" -le 128 ] || exit 2
+			[ -n "$2" ] || exit 2
+			case "$2" in
+				*"
+"*|*"	"*) exit 2 ;;
+			esac
+			case "$1" in
+				--bootstrap) printf '%s\n' "$2" >> "$bootstrap_file" ;;
+				--upstream) printf '%s\n' "$2" >> "$upstream_file" ;;
+				--fallback) printf '%s\n' "$2" >> "$fallback_file" ;;
+			esac
+			shift 2
+			;;
+		*) exit 2 ;;
+	esac
+done
+
+[ -s "$upstream_file" ] || exit 2
+command -v dnsproxy >/dev/null 2>&1 || exit 127
+command -v nslookup >/dev/null 2>&1 || exit 127
+
+test_server() {
+	kind="$1"
+	server="$2"
+	port=$((30000 + ($$ + count) % 20000))
+	count=$((count + 1))
+
+	set -- dnsproxy \
+		--listen 127.0.0.1 \
+		--port "$port" \
+		--upstream "$server" \
+		--upstream-mode "$mode" \
+		--timeout 5s
+
+	while IFS= read -r bootstrap; do
+		[ -n "$bootstrap" ] && set -- "$@" --bootstrap "$bootstrap"
+	done < "$bootstrap_file"
+
+	"$@" > "$log_file" 2>&1 &
+	pid=$!
+	sleep 1
+
+	output="$(nslookup -debug -type=A -timeout=5 -retry=1 -port="$port" openwrt.org 127.0.0.1 2>&1)"
+	status=$?
+
+	kill "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+	pid=''
+
+	latency="$(printf '%s\n' "$output" | sed -n 's/.*completed in \([0-9][0-9]*\)ms.*/\1/p' | head -n 1)"
+	if [ "$status" -eq 0 ]; then
+		printf '%s\tok\t%s\t%s\n' "$kind" "${latency:--}" "$server"
+	else
+		reason="$(printf '%s\n' "$output" | tail -n 1 | tr '\t' ' ')"
+		[ -n "$reason" ] || reason="$(tail -n 1 "$log_file" | tr '\t' ' ')"
+		printf '%s\terror\t-\t%s\t%s\n' "$kind" "$server" "$reason"
+	fi
+}
+
+while IFS= read -r server; do
+	[ -n "$server" ] && test_server upstream "$server"
+done < "$upstream_file"
+
+while IFS= read -r server; do
+	[ -n "$server" ] && test_server fallback "$server"
+done < "$fallback_file"
+
+exit 0

--- a/root/usr/libexec/dnsproxy-profile-test
+++ b/root/usr/libexec/dnsproxy-profile-test
@@ -25,10 +25,16 @@ mkdir -m 0700 "$tmpdir" || exit 1
 : > "$fallback_file"
 
 mode='load_balance'
+domain='openwrt.org'
 count=0
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
+		--domain)
+			[ "$#" -ge 2 ] || exit 2
+			domain="$2"
+			shift 2
+			;;
 		--upstream-mode)
 			[ "$#" -ge 2 ] || exit 2
 			case "$2" in
@@ -57,6 +63,25 @@ while [ "$#" -gt 0 ]; do
 	esac
 done
 
+hostname="${domain%.}"
+[ -n "$hostname" ] || exit 2
+[ "${#hostname}" -le 253 ] || exit 2
+case "$hostname" in
+	.*|*..*|*[!A-Za-z0-9.-]*) exit 2 ;;
+esac
+
+old_ifs="$IFS"
+IFS='.'
+set -- $hostname
+IFS="$old_ifs"
+for label do
+	[ -n "$label" ] || exit 2
+	[ "${#label}" -le 63 ] || exit 2
+	case "$label" in
+		-*|*-) exit 2 ;;
+	esac
+done
+
 [ -s "$upstream_file" ] || exit 2
 command -v dnsproxy >/dev/null 2>&1 || exit 127
 command -v nslookup >/dev/null 2>&1 || exit 127
@@ -82,7 +107,7 @@ test_server() {
 	pid=$!
 	sleep 1
 
-	output="$(nslookup -debug -type=A -timeout=5 -retry=1 -port="$port" openwrt.org 127.0.0.1 2>&1)"
+	output="$(nslookup -debug -type=A -timeout=5 -retry=1 -port="$port" "$domain" 127.0.0.1 2>&1)"
 	status=$?
 
 	kill "$pid" 2>/dev/null || true

--- a/root/usr/libexec/dnsproxy-profile-test
+++ b/root/usr/libexec/dnsproxy-profile-test
@@ -17,40 +17,64 @@ cleanup() {
 	rm -rf "$tmpdir"
 }
 
+fail() {
+	printf '%s\n' "$1" >&2
+	exit "${2:-1}"
+}
+
 trap cleanup EXIT INT TERM
 
-mkdir -m 0700 "$tmpdir" || exit 1
+mkdir -m 0700 "$tmpdir" || fail 'Unable to create a temporary test directory.'
 : > "$bootstrap_file"
 : > "$upstream_file"
 : > "$fallback_file"
 
 mode='load_balance'
 domain='openwrt.org'
-count=0
+attempts=3
+query_type='A'
+item_count=0
+port_seed=0
 
 while [ "$#" -gt 0 ]; do
 	case "$1" in
 		--domain)
-			[ "$#" -ge 2 ] || exit 2
+			[ "$#" -ge 2 ] || fail 'Missing value for --domain.' 2
 			domain="$2"
 			shift 2
 			;;
+		--attempts)
+			[ "$#" -ge 2 ] || fail 'Missing value for --attempts.' 2
+			case "$2" in
+				1|3|5|10) attempts="$2" ;;
+				*) fail 'Attempts must be one of: 1, 3, 5, 10.' 2 ;;
+			esac
+			shift 2
+			;;
+		--query-type)
+			[ "$#" -ge 2 ] || fail 'Missing value for --query-type.' 2
+			case "$2" in
+				A|AAAA|both) query_type="$2" ;;
+				*) fail 'Query type must be A, AAAA, or both.' 2 ;;
+			esac
+			shift 2
+			;;
 		--upstream-mode)
-			[ "$#" -ge 2 ] || exit 2
+			[ "$#" -ge 2 ] || fail 'Missing value for --upstream-mode.' 2
 			case "$2" in
 				load_balance|parallel|fastest_addr) mode="$2" ;;
-				*) exit 2 ;;
+				*) fail 'Unsupported upstream selection mode.' 2 ;;
 			esac
 			shift 2
 			;;
 		--bootstrap|--upstream|--fallback)
-			[ "$#" -ge 2 ] || exit 2
-			count=$((count + 1))
-			[ "$count" -le 128 ] || exit 2
-			[ -n "$2" ] || exit 2
+			[ "$#" -ge 2 ] || fail "Missing value for $1." 2
+			item_count=$((item_count + 1))
+			[ "$item_count" -le 384 ] || fail 'Too many DNS server values were supplied.' 2
+			[ -n "$2" ] || fail 'DNS server values must not be empty.' 2
 			case "$2" in
 				*"
-"*|*"	"*) exit 2 ;;
+"*|*"	"*) fail 'DNS server values must not contain tabs or newlines.' 2 ;;
 			esac
 			case "$1" in
 				--bootstrap) printf '%s\n' "$2" >> "$bootstrap_file" ;;
@@ -59,15 +83,15 @@ while [ "$#" -gt 0 ]; do
 			esac
 			shift 2
 			;;
-		*) exit 2 ;;
+		*) fail "Unknown argument: $1" 2 ;;
 	esac
 done
 
 hostname="${domain%.}"
-[ -n "$hostname" ] || exit 2
-[ "${#hostname}" -le 253 ] || exit 2
+[ -n "$hostname" ] || fail 'Test domain is empty.' 2
+[ "${#hostname}" -le 253 ] || fail 'Test domain is longer than 253 characters.' 2
 case "$hostname" in
-	.*|*..*|*[!A-Za-z0-9.-]*) exit 2 ;;
+	.*|*..*|*[!A-Za-z0-9.-]*) fail 'Test domain is not a valid ASCII or Punycode DNS name.' 2 ;;
 esac
 
 old_ifs="$IFS"
@@ -75,54 +99,185 @@ IFS='.'
 set -- $hostname
 IFS="$old_ifs"
 for label do
-	[ -n "$label" ] || exit 2
-	[ "${#label}" -le 63 ] || exit 2
+	[ -n "$label" ] || fail 'Test domain contains an empty DNS label.' 2
+	[ "${#label}" -le 63 ] || fail 'Test domain contains a label longer than 63 characters.' 2
 	case "$label" in
-		-*|*-) exit 2 ;;
+		-*|*-) fail 'Test domain contains a label beginning or ending with a hyphen.' 2 ;;
 	esac
 done
 
-[ -s "$upstream_file" ] || exit 2
-command -v dnsproxy >/dev/null 2>&1 || exit 127
-command -v nslookup >/dev/null 2>&1 || exit 127
+[ -s "$upstream_file" ] || fail 'The profile has no upstream DNS servers.' 2
+command -v dnsproxy >/dev/null 2>&1 || fail 'dnsproxy executable was not found. Install the dnsproxy package first.' 127
+command -v nslookup >/dev/null 2>&1 || fail 'nslookup executable was not found. Install bind-host or a package that provides nslookup.' 127
+
+sanitize() {
+	printf '%s' "$1" | tr '\t\r\n' '   ' | sed 's/  */ /g; s/^ //; s/ $//'
+}
+
+diagnose() {
+	message="$(sanitize "$1")"
+	lower="$(printf '%s' "$message" | tr 'A-Z' 'a-z')"
+	case "$lower" in
+		*certificate*|*x509*|*tls*handshake*|*tls*verify*) printf '%s' 'TLS certificate validation failed' ;;
+		*bootstrap*|*no\ such\ host*|*cannot\ resolve*|*failed\ to\ resolve*) printf '%s' 'Bootstrap name resolution failed' ;;
+		*timed\ out*|*timeout*|*no\ servers\ could\ be\ reached*) printf '%s' 'DNS query timed out' ;;
+		*connection\ refused*) printf '%s' 'Connection was refused' ;;
+		*) printf '%s' "${message:-DNS query failed}" ;;
+	esac
+}
+
+query_types() {
+	case "$query_type" in
+		both) printf '%s\n' A AAAA ;;
+		*) printf '%s\n' "$query_type" ;;
+	esac
+}
+
+emit_start_failure() {
+	kind="$1"
+	server="$2"
+	detail="$3"
+	query_types | while IFS= read -r record; do
+		printf '%s\t%s\terror\t0\t%s\t-\t-\t-\t%s\t%s\n' \
+			"$kind" "$record" "$attempts" "$server" "$(sanitize "$detail")"
+	done
+}
+
+start_proxy() {
+	kind="$1"
+	server="$2"
+	port_attempt=0
+
+	while [ "$port_attempt" -lt 8 ]; do
+		port_seed=$((port_seed + 1))
+		port=$((30000 + ($$ + port_seed * 97) % 20000))
+		: > "$log_file"
+
+		set -- dnsproxy --listen 127.0.0.1 --port "$port" --upstream "$server" \
+			--upstream-mode "$mode" --timeout 5s
+
+		if [ "$kind" != 'bootstrap' ]; then
+			while IFS= read -r bootstrap; do
+				[ -n "$bootstrap" ] && set -- "$@" --bootstrap "$bootstrap"
+			done < "$bootstrap_file"
+		fi
+
+		if [ "$kind" = 'failover' ]; then
+			while IFS= read -r fallback; do
+				[ -n "$fallback" ] && set -- "$@" --fallback "$fallback"
+			done < "$fallback_file"
+		fi
+
+		"$@" > "$log_file" 2>&1 &
+		pid=$!
+		sleep 1
+		if kill -0 "$pid" 2>/dev/null; then
+			return 0
+		fi
+
+		wait "$pid" 2>/dev/null || true
+		pid=''
+		log="$(cat "$log_file" 2>/dev/null)"
+		case "$(printf '%s' "$log" | tr 'A-Z' 'a-z')" in
+			*address\ already\ in\ use*|*bind:*in\ use*)
+				port_attempt=$((port_attempt + 1))
+				continue
+				;;
+		esac
+		start_error="Failed to start temporary DNS Proxy: $(diagnose "$log")"
+		return 11
+	done
+
+	start_error='All temporary test ports tried were already occupied.'
+	return 10
+}
+
+stop_proxy() {
+	if [ -n "$pid" ]; then
+		kill "$pid" 2>/dev/null || true
+		wait "$pid" 2>/dev/null || true
+		pid=''
+	fi
+}
+
+measure_record() {
+	kind="$1"
+	server="$2"
+	record="$3"
+	index=1
+	success=0
+	errors=0
+	timed=0
+	sum=0
+	minimum=''
+	maximum=''
+	detail=''
+
+	while [ "$index" -le "$attempts" ]; do
+		output="$(nslookup -debug -type="$record" -timeout=5 -retry=1 -port="$port" "$domain" 127.0.0.1 2>&1)"
+		status=$?
+		latency="$(printf '%s\n' "$output" | sed -n 's/.*completed in \([0-9][0-9]*\)ms.*/\1/p' | head -n 1)"
+
+		if [ "$status" -eq 0 ]; then
+			success=$((success + 1))
+			if [ -n "$latency" ]; then
+				timed=$((timed + 1))
+				sum=$((sum + latency))
+				[ -n "$minimum" ] || minimum="$latency"
+				[ "$latency" -lt "$minimum" ] && minimum="$latency"
+				[ -n "$maximum" ] || maximum="$latency"
+				[ "$latency" -gt "$maximum" ] && maximum="$latency"
+			fi
+		else
+			errors=$((errors + 1))
+			[ -n "$detail" ] || detail="$(diagnose "$output $(cat "$log_file" 2>/dev/null)")"
+		fi
+		index=$((index + 1))
+	done
+
+	if [ "$success" -eq 0 ]; then
+		result='error'
+	elif [ "$errors" -gt 0 ]; then
+		result='partial'
+	else
+		result='ok'
+	fi
+
+	if [ -n "$minimum" ]; then
+		average=$((sum / timed))
+	else
+		minimum='-'
+		average='-'
+		maximum='-'
+	fi
+
+	if [ "$kind" = 'failover' ] && [ "$success" -gt 0 ]; then
+		detail='Fallback activated successfully'
+	elif [ -z "$detail" ] && [ "$errors" -gt 0 ]; then
+		detail="$errors failed attempt(s)"
+	fi
+
+	printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$kind" "$record" "$result" "$success" "$attempts" "$minimum" "$average" "$maximum" \
+		"$server" "$(sanitize "$detail")"
+}
 
 test_server() {
 	kind="$1"
 	server="$2"
-	port=$((30000 + ($$ + count) % 20000))
-	count=$((count + 1))
-
-	set -- dnsproxy \
-		--listen 127.0.0.1 \
-		--port "$port" \
-		--upstream "$server" \
-		--upstream-mode "$mode" \
-		--timeout 5s
-
-	while IFS= read -r bootstrap; do
-		[ -n "$bootstrap" ] && set -- "$@" --bootstrap "$bootstrap"
-	done < "$bootstrap_file"
-
-	"$@" > "$log_file" 2>&1 &
-	pid=$!
-	sleep 1
-
-	output="$(nslookup -debug -type=A -timeout=5 -retry=1 -port="$port" "$domain" 127.0.0.1 2>&1)"
-	status=$?
-
-	kill "$pid" 2>/dev/null || true
-	wait "$pid" 2>/dev/null || true
-	pid=''
-
-	latency="$(printf '%s\n' "$output" | sed -n 's/.*completed in \([0-9][0-9]*\)ms.*/\1/p' | head -n 1)"
-	if [ "$status" -eq 0 ]; then
-		printf '%s\tok\t%s\t%s\n' "$kind" "${latency:--}" "$server"
-	else
-		reason="$(printf '%s\n' "$output" | tail -n 1 | tr '\t' ' ')"
-		[ -n "$reason" ] || reason="$(tail -n 1 "$log_file" | tr '\t' ' ')"
-		printf '%s\terror\t-\t%s\t%s\n' "$kind" "$server" "$reason"
+	if ! start_proxy "$kind" "$server"; then
+		emit_start_failure "$kind" "$server" "$start_error"
+		return
 	fi
+	query_types | while IFS= read -r record; do
+		measure_record "$kind" "$server" "$record"
+	done
+	stop_proxy
 }
+
+while IFS= read -r server; do
+	[ -n "$server" ] && test_server bootstrap "$server"
+done < "$bootstrap_file"
 
 while IFS= read -r server; do
 	[ -n "$server" ] && test_server upstream "$server"
@@ -131,5 +286,9 @@ done < "$upstream_file"
 while IFS= read -r server; do
 	[ -n "$server" ] && test_server fallback "$server"
 done < "$fallback_file"
+
+if [ -s "$fallback_file" ]; then
+	test_server failover '127.0.0.1:1'
+fi
 
 exit 0

--- a/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json
@@ -2,6 +2,9 @@
 	"luci-app-dnsproxy": {
 		"description": "Grant access to LuCI app dnsproxy",
 		"read": {
+			"file": {
+				"/usr/libexec/dnsproxy-profile-test": [ "exec" ]
+			},
 			"ubus": {
 				"luci-rpc": [ "getHostHints" ],
 				"service": [ "list" ]

--- a/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-dnsproxy.json
@@ -2,6 +2,7 @@
 	"luci-app-dnsproxy": {
 		"description": "Grant access to LuCI app dnsproxy",
 		"read": {
+			"cgi-io": [ "exec" ],
 			"file": {
 				"/usr/libexec/dnsproxy-profile-test": [ "exec" ]
 			},


### PR DESCRIPTION
# Add reusable DNS profile management

## What changed

- Add editable DNS profiles containing Bootstrap, Upstream, Fallback, and upstream-selection mode settings.
- Show the profile matching the active DNS configuration, or identify it as a custom configuration.
- Preview an exact Bootstrap, Upstream, Fallback, and selection-mode diff before loading a profile or replacing a saved profile.
- Load a profile into the form for review before the standard **Save & Apply** action instead of changing the running configuration immediately.
- Create a profile from the current form values and update an existing profile after reviewing the changes.
- Validate required upstreams, unique profile names, duplicate servers, whitespace, control characters, list size, and supported selection modes.
- Test every Bootstrap, Upstream, and Fallback independently through a temporary `dnsproxy` instance bound to loopback without changing the running service.
- Select 1, 3, 5, or 10 measurements and A, AAAA, or A+AAAA queries; report successes, errors, and minimum, average, and maximum response time.
- Sort and color-code test results, remember the last test domain in browser-local storage, and provide actionable dependency, startup, TLS, bootstrap, port-conflict, and timeout diagnostics.
- Verify actual fallback activation with a deliberately unavailable primary resolver.
- Compare all saved profiles sequentially with identical test settings and a summary table.
- Run long profile tests through LuCI's direct CGI execution path so they are not terminated by the default 20-second RPC timeout.
- Preserve empty trailing result fields and surface plain helper diagnostics instead of reporting them as an unsupported result format.
- Import and export individual profiles or the complete profile set as versioned JSON.
- Keep the profile manager collapsed by default and display all profile controls only on the **Upstreams** tab.
- Include editable example profiles for Cloudflare, Quad9, Google, and a mixed parallel setup.
- Replace the obsolete `all_servers` and `fastest_addr` LuCI flags with the `upstream_mode` option used by current OpenWrt `dnsproxy` packages.
- Migrate existing upstream-mode values without overwriting existing profiles.
- Update the README and translation template.

## Why

Switching between DNS providers currently requires editing multiple lists and remembering the matching upstream mode. Profiles make complete DNS configurations reusable while a preview-first workflow avoids unexpected service changes.

The existing upstream-mode checkboxes write `all_servers` and `fastest_addr`, but current OpenWrt `dnsproxy` packages read `global.upstream_mode`. As a result, those controls may not affect the running service. This change maps the UI directly to the supported `load_balance`, `parallel`, and `fastest_addr` values and migrates existing settings.

## User impact

Users can identify the active profile, preview exact changes, save or update templates from the form, benchmark and compare resolvers against a domain of their choice, verify fallback operation, and transfer profiles between routers. The running DNS configuration is only changed through the normal LuCI **Save & Apply** workflow. Existing installations retain their selected upstream behavior through migration.

## Validation

- LuCI ESLint
- `sh -n root/etc/uci-defaults/99-luci-app-dnsproxy-defaults`
- `sh -n root/usr/libexec/dnsproxy-profile-test`
- Test-domain and test-option validation cases
- Mocked end-to-end helper runs for Bootstrap, Upstream, Fallback, A/AAAA statistics, and fallback activation
- JSON validation for the rpcd ACL file
- `git diff --check`
